### PR TITLE
don't throw error for non-transparent link

### DIFF
--- a/apps/app/src/app/[handle]/links/_components/create-or-update-link-modal.tsx
+++ b/apps/app/src/app/[handle]/links/_components/create-or-update-link-modal.tsx
@@ -169,8 +169,9 @@ export function CreateOrUpdateLinkModal(props: { mode: 'create' | 'update' }) {
 	const handleCloseModal = useCallback(async () => {
 		form.reset();
 		focusGridList();
+		setShowLinkModal(false);
 		await apiUtils.link.byWorkspace.invalidate();
-	}, [focusGridList, form, apiUtils.link]);
+	}, [focusGridList, form, apiUtils.link, setShowLinkModal]);
 
 	const LinkIconOrFavicon = useMemo(() => {
 		if (!metaTags?.favicon) return null;

--- a/packages/lib/server/routes/link/link.router.ts
+++ b/packages/lib/server/routes/link/link.router.ts
@@ -68,10 +68,10 @@ export const linkRouter = createTRPCRouter({
 	create: privateProcedure.input(createLinkSchema).mutation(async ({ input, ctx }) => {
 		const transparentLinkData = getTransparentLinkDataFromUrl(input.url, ctx.workspace);
 
-		if (!transparentLinkData) {
+		if (input.transparent && !transparentLinkData) {
 			throw new TRPCError({
 				code: 'BAD_REQUEST',
-				message: `Invalid URL`,
+				message: `Invalid URL for transparent link`,
 			});
 		}
 

--- a/packages/lib/utils/link.ts
+++ b/packages/lib/utils/link.ts
@@ -86,12 +86,16 @@ export function getTransparentLinkDataFromUrl(url: string, workspace: SessionWor
 	// an example url: https://www.youtube.com/channel/UC-lHJZR3Gqxm24_Vd_AJ5Yw
 	// in this case, the app would be 'youtube', the appRoute would be 'channel', and the appId would be 'UC-lHJZR3Gqxm24_Vd_AJ5Yw'
 
-	if (!isValidUrl(url)) return null;
+	if (!isValidUrl(url)) {
+		console.log('url is not valid');
+		return null;
+	}
 
 	// get the domain of the url (e.g. 'youtube.com' or 'open.spotify.com')
 	const domain = getDomainWithoutWWW(url);
 
 	if (!domain) {
+		console.log('domain is not valid');
 		return null;
 	}
 
@@ -108,14 +112,6 @@ export function getTransparentLinkDataFromUrl(url: string, workspace: SessionWor
 			app = 'spotify';
 			searchParams.delete('si');
 			console.log('wsSpotArtistId', workspace?.spotifyArtistId);
-			// const isCurrentArtistPage =
-			// 	pathname.startsWith('/artist/') &&
-			// 	pathname.split('/')[2] === workspace?.spotifyArtistId;
-
-			// if (isCurrentArtistPage) {
-			// 	pathname = '';
-			// }
-
 			break;
 		}
 


### PR DESCRIPTION
* fixed an issue where link.create was throwing errors if transparentLinkData was null, even if the link wasn't set to be a transparent link.
* close link modal on create/update