### PR TITLE
fix purchase event logging errors

### DIFF
--- a/packages/lib/server/routes/cart/cart.router.ts
+++ b/packages/lib/server/routes/cart/cart.router.ts
@@ -407,14 +407,6 @@ export const cartRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {
-			// if (!ctx.visitor?.ip) {
-			// 	console.log(
-			// 		`no visitor ip to log cart event [${input.event}] for cart ${input.cartId}. visitor >> `,
-			// 		ctx.visitor,
-			// 	);
-			// 	return;
-			// }
-
 			const cart =
 				(await ctx.db.pool.query.Carts.findFirst({
 					where: eq(Carts.id, input.cartId),
@@ -443,13 +435,16 @@ export const cartRouter = createTRPCRouter({
 			if (!cart.visitorReferer) updateCart.visitorReferer = ctx.visitor?.referer;
 			if (!cart.visitorRefererUrl)
 				updateCart.visitorRefererUrl = ctx.visitor?.referer_url;
+			if (!cart.visitorCheckoutHref && input.event === 'cart_initiateCheckout')
+				updateCart.visitorCheckoutHref = ctx.visitor?.href;
 
 			if (
 				!!updateCart.visitorIp ||
 				!!updateCart.visitorGeo ||
 				!!updateCart.visitorUserAgent ||
 				!!updateCart.visitorReferer ||
-				!!updateCart.visitorRefererUrl
+				!!updateCart.visitorRefererUrl ||
+				!!updateCart.visitorCheckoutHref
 			) {
 				await ctx.db.pool.update(Carts).set(updateCart).where(eq(Carts.id, cart.id));
 			}

--- a/packages/lib/server/routes/cart/cart.sql.ts
+++ b/packages/lib/server/routes/cart/cart.sql.ts
@@ -57,6 +57,8 @@ export const Carts = pgTable(
 		visitorReferer: varchar('visitorReferer', { length: 255 }),
 		visitorRefererUrl: varchar('visitorRefererUrl', { length: 255 }),
 
+		visitorCheckoutHref: varchar('visitorCheckoutHref', { length: 255 }),
+
 		// stripe (on creation)
 		checkoutStripePaymentIntentId: varchar('checkoutStripePaymentIntentId', {
 			length: 255,

--- a/packages/lib/server/routes/event/event.fns.ts
+++ b/packages/lib/server/routes/event/event.fns.ts
@@ -208,7 +208,11 @@ export async function recordCartEvent({
 		referer: cart.visitorReferer ?? visitor?.referer ?? 'Unknown',
 		referer_url: cart.visitorRefererUrl ?? visitor?.referer_url ?? 'Unknown',
 		isBot: visitor?.isBot ?? false,
-		href: visitor?.href ?? 'Unknown',
+		// href: visitor?.href ?? 'Unknown',
+		href:
+			type === 'cart_purchaseMainWithoutBump' || type === 'cart_purchaseMainWithBump' ?
+				cart.visitorCheckoutHref ?? visitor?.href ?? 'Unknown'
+			:	visitor?.href ?? 'Unknown',
 	};
 
 	if (visitorInfo.isBot) return null;


### PR DESCRIPTION
- add shipping address to order in stripe connect webhook (it was already being added to fan, but not to order)
- add visitorCheckoutHref to cart and use when reporting checkout purchase to meta