### PR TITLE
cart updates

### DIFF
--- a/apps/app/src/app/[handle]/carts/_components/create-or-update-cartFunnel-modal.tsx
+++ b/apps/app/src/app/[handle]/carts/_components/create-or-update-cartFunnel-modal.tsx
@@ -10,6 +10,7 @@ import {
 	upsertCartFunnelSchema,
 } from '@barely/lib/server/routes/cart-funnel/cart-funnel.schema';
 
+import { Button } from '@barely/ui/elements/button';
 import { Label } from '@barely/ui/elements/label';
 import { MDXEditor } from '@barely/ui/elements/mdx-editor';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '@barely/ui/elements/modal';
@@ -99,6 +100,10 @@ export function CreateOrUpdateFunnelModal({ mode }: { mode: 'create' | 'update' 
 
 		await apiUtils.cartFunnel.invalidate();
 	}, [setShowModal, focusGridList, apiUtils.cartFunnel]);
+
+	// state
+	// const bumpSelected = form.watch('bumpProductId') !== null;
+	const upsellSelected = !!form.watch('upsellProductId');
 
 	return (
 		<Modal
@@ -197,22 +202,39 @@ export function CreateOrUpdateFunnelModal({ mode }: { mode: 'create' | 'update' 
 
 					{/* UPSELL */}
 					<H size='3'>Upsell</H>
+
 					<SelectField
 						control={form.control}
 						name='upsellProductId'
 						label='Upsell Product'
+						labelButton={
+							upsellSelected ?
+								<Button
+									startIcon='x'
+									variant='icon'
+									size='xs'
+									look='minimal'
+									onClick={() =>
+										form.setValue('upsellProductId', null, { shouldDirty: true })
+									}
+								/>
+							:	null
+						}
 						options={productOptions}
 					/>
+
 					<TextField
 						control={form.control}
 						name='upsellProductHeadline'
 						label='Headline'
+						// disabled={!upsellSelected}
 					/>
 					<CurrencyField
 						control={form.control}
 						name='upsellProductDiscount'
 						label='Discount'
 						outputUnits='cents'
+						// disabled={!upsellSelected}
 					/>
 
 					<Label>Above the Fold</Label>

--- a/apps/app/src/app/[handle]/press/_components/sortable-media.tsx
+++ b/apps/app/src/app/[handle]/press/_components/sortable-media.tsx
@@ -42,6 +42,7 @@ export function MediaListBoxCard(props: MediaCardProps) {
 	return (
 		<ListBoxItem id={file.id} key={file.id} textValue={file.name}>
 			<MediaCard {...props} />
+			{/* {file.lexorank} */}
 		</ListBoxItem>
 	);
 }
@@ -61,9 +62,14 @@ export function SortableMedia({
 }) {
 	const { dragAndDropHooks } = useDragAndDrop({
 		getItems: keys => {
-			const fileRecords = [...keys].map(key => ({
-				fileRecord: JSON.stringify(media.find(f => f.id === key)) ?? '',
-			}));
+			const fileRecords = [...keys].map(key => {
+				const file = media.find(f => f.id === key);
+				return {
+					'text/plain': file?.id ?? '',
+					fileRecord: JSON.stringify(file) ?? '',
+					...(file?.type === 'image' ? { imageRecord: JSON.stringify(file) } : {}),
+				};
+			});
 			return fileRecords;
 		},
 

--- a/apps/cart/src/app/[mode]/[handle]/[key]/checkout/page.tsx
+++ b/apps/cart/src/app/[mode]/[handle]/[key]/checkout/page.tsx
@@ -29,6 +29,12 @@ export default async function CartPage({
 		return redirect('/');
 	}
 
+	console.log('cartParams', cartParams.data);
+
+	if (cartParams.data.warmup) {
+		return <div>warmingup</div>;
+	}
+
 	const cartId = cookies().get(`${handle}.${key}.cartId`)?.value;
 
 	//  estimate shipTo from IP

--- a/apps/cart/src/app/api/trpc/cart/[trpc]/route.ts
+++ b/apps/cart/src/app/api/trpc/cart/[trpc]/route.ts
@@ -7,7 +7,20 @@ import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
 
 export { OPTIONS } from '@barely/lib/utils/trpc-route';
 
-const handler = async function (req: NextRequest) {
+const handler = async function (
+	req: NextRequest,
+	// { params }: { params: { trpc: string } },
+) {
+	// if (params.trpc === 'warmup') {
+	//     // currently just trying to warmup the cart
+	// 	console.log('trpc cart warmup');
+
+	// 	return new Response(null, {
+	// 		statusText: 'OK',
+	// 		status: 200,
+	// 	});
+	// }
+
 	const visitor = parseReqForVisitorInfo(req);
 	console.log('trpc cart visitor >>', visitor);
 

--- a/apps/cart/src/middleware.ts
+++ b/apps/cart/src/middleware.ts
@@ -8,6 +8,8 @@ export function middleware(req: NextRequest) {
 
 	console.log('domain', domain);
 	console.log('path', pathname);
+	// what about query params
+	console.log('query', req.nextUrl.search);
 
 	/* the mode is already set in the URL */
 	if (
@@ -20,16 +22,15 @@ export function middleware(req: NextRequest) {
 
 	/* the mode is set in the subdomain. set the mode in the URL */
 	if (domain?.startsWith('preview.')) {
-		const previewUrl = getAbsoluteUrl('cart', `preview${pathname}`).replace(
-			'www.',
-			'preview.',
-		);
+		const previewUrl =
+			getAbsoluteUrl('cart', `preview${pathname}`).replace('www.', 'preview.') +
+			req.nextUrl.search;
 		console.log('pushing to preview', previewUrl);
 		return NextResponse.rewrite(previewUrl);
 	}
 
 	/* assuming we are in live mode */
-	const liveUrl = getAbsoluteUrl('cart', `live${pathname}`);
+	const liveUrl = getAbsoluteUrl('cart', `live${pathname}${req.nextUrl.search}`);
 	console.log('pushing to live', liveUrl);
 	return NextResponse.rewrite(liveUrl);
 }

--- a/apps/page/src/app/[handle]/[...key]/page.tsx
+++ b/apps/page/src/app/[handle]/[...key]/page.tsx
@@ -6,6 +6,8 @@ import { mdxAssetButton } from '@barely/ui/elements/mdx-asset-button';
 import { mdxTypography } from '@barely/ui/elements/mdx-typography';
 import { mdxVideoPlayer } from '@barely/ui/elements/mdx-video-player';
 
+import { WarmupCart } from '~/app/[handle]/[...key]/warmup-cart';
+
 export async function generateMetadata({
 	params,
 }: {
@@ -55,6 +57,7 @@ export default async function LandingPage({
 
 	return (
 		<div className='mx-auto flex min-h-screen w-full max-w-3xl flex-col items-center gap-6 px-4 py-10'>
+			{cartFunnels?.length > 0 && <WarmupCart />}
 			<MDXRemote
 				source={lp.content ?? ''}
 				components={{

--- a/apps/page/src/app/[handle]/[...key]/warmup-cart.tsx
+++ b/apps/page/src/app/[handle]/[...key]/warmup-cart.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { isProduction } from '@barely/lib/utils/environment';
+import { getAbsoluteUrl } from '@barely/lib/utils/url';
+
+export function WarmupCart() {
+	const hasWarmedUp = useRef(false);
+
+	useEffect(() => {
+		if (isProduction() && !hasWarmedUp.current) {
+			fetch(
+				getAbsoluteUrl('cart', `live/warmup/warmup`, {
+					// i don't think the handle/key are necessary here
+					query: {
+						warmup: 'true',
+					},
+				}),
+			).catch(console.error);
+
+			hasWarmedUp.current = true;
+		}
+	}, []);
+
+	return null;
+}

--- a/packages/lib/server/meta/meta.endpts.event.ts
+++ b/packages/lib/server/meta/meta.endpts.event.ts
@@ -17,12 +17,19 @@ interface MetaEventParams {
 	currency?: string;
 	num_items?: number;
 	value?: number;
-	// barely params
+
+	/* barely params */
+	// cart
 	cartId?: string;
-	withBump?: boolean;
-	linkType?: 'short' | 'transparent';
+	cartPurchaseType?: 'mainWithoutBump' | 'mainWithBump' | 'upsell';
+	upsellProductId?: string;
+
+	// fm
 	fmId?: string;
 	destinationPlatform?: (typeof FM_LINK_PLATFORMS)[number];
+
+	// link
+	linkType?: 'short' | 'transparent';
 }
 
 const META_EVENT_NAMES = [
@@ -33,10 +40,10 @@ const META_EVENT_NAMES = [
 	'barely.cart/addPaymentInfo',
 	'barely.cart/addBump',
 	'barely.cart/removeBump',
-	'barely.cart/purchaseMain',
+	// 'barely.cart/purchaseMain',
+	'barely.cart/purchase',
 	'barely.cart/viewUpsell',
 	'barely.cart/declineUpsell',
-	'barely.cart/purchaseUpsell',
 	'barely.cart/viewOrderConfirmation',
 
 	// fm

--- a/packages/lib/server/routes/cart/cart.schema.ts
+++ b/packages/lib/server/routes/cart/cart.schema.ts
@@ -53,7 +53,10 @@ export const cartPageSearchParams = insertCartSchema
 		bumpProductQuantity: true,
 		bumpProductApparelSize: true,
 	})
-	.partial();
+	.partial()
+	.extend({
+		warmup: z.coerce.boolean().optional(),
+	});
 
 export const updateCheckoutCartFromCheckoutSchema = cartPageSearchParams
 	.required({ id: true })

--- a/packages/lib/server/routes/event/event.fns.ts
+++ b/packages/lib/server/routes/event/event.fns.ts
@@ -368,26 +368,26 @@ function getMetaEventFromCartEvent({
 			};
 		case 'cart/purchaseMainWithoutBump':
 			return {
-				eventName: 'barely.cart/purchaseMain',
+				eventName: 'barely.cart/purchase',
 				customData: {
 					cartId: cart.id,
 					content_ids: [cart.mainProductId],
 					content_type: 'product',
 					currency: 'USD',
-					withBump: false,
+					cartPurchaseType: 'mainWithoutBump',
 					value: cart.checkoutAmount,
 				},
 			};
 		case 'cart/purchaseMainWithBump':
 			if (!cart.bumpProductId) return null;
 			return {
-				eventName: 'barely.cart/purchaseMain',
+				eventName: 'barely.cart/purchase',
 				customData: {
 					cartId: cart.id,
 					content_ids: [cart.mainProductId, cart.bumpProductId],
 					content_type: 'product',
 					currency: 'USD',
-					withBump: true,
+					cartPurchaseType: 'mainWithBump',
 					value: cart.checkoutAmount,
 				},
 			};
@@ -404,12 +404,14 @@ function getMetaEventFromCartEvent({
 		case 'cart/purchaseUpsell':
 			if (!cart.upsellProductId) return null;
 			return {
-				eventName: 'barely.cart/purchaseUpsell',
+				eventName: 'barely.cart/purchase',
 				customData: {
 					cartId: cart.id,
+					upsellProductId: cart.upsellProductId,
 					content_ids: [cart.upsellProductId],
 					content_type: 'product',
 					currency: 'USD',
+					cartPurchaseType: 'upsell',
 					value: cart.upsellProductPrice ?? 0,
 				},
 			};

--- a/packages/ui/forms/select-field.tsx
+++ b/packages/ui/forms/select-field.tsx
@@ -40,7 +40,7 @@ export const SelectField = <
 						<FieldWrapper {...props} hint={hint}>
 							<Select
 								onValueChange={field.onChange}
-								defaultValue={field.value}
+								value={field.value}
 								disabled={props.disabled}
 							>
 								<FormControl>


### PR DESCRIPTION
- combined meta events for purchase (mainWithoutBump, mainWithBump, & upsell) to a single event (barely.cart/purchase) with a 'cartPurchaseType' param. Will likely focus more on aggregated value param in the future
- send a warmup call to cart page when landingPage with at least one cart button is loaded
- added option to clear upsell from cartFunnel
- check for improper lexoranks during 'insert' function and heal if necessary
- add 'imageRecord' type to getItems in SortableMedia so that images can be sorted if 'imageRecord' is the only specified drag type. Makes imageRecord actually sortable now.