### PR TITLE
updating sourceUrl for reporting meta events w/ CAPI

### DIFF
--- a/packages/lib/server/routes/event/event.fns.ts
+++ b/packages/lib/server/routes/event/event.fns.ts
@@ -108,7 +108,7 @@ export async function recordLinkClick({
 			await reportEventToMeta({
 				pixelId: metaPixel.id,
 				accessToken: metaPixel.accessToken,
-				url: href,
+				sourceUrl: href, // this is being logged directly from middleware, so href is the sourceUrl
 				ip,
 				ua: ua.ua,
 				eventName: 'barely.link/click',
@@ -218,6 +218,7 @@ export async function recordCartEvent({
 		referer: cart.visitorReferer ?? visitor?.referer ?? 'Unknown',
 		referer_url: cart.visitorRefererUrl ?? visitor?.referer_url ?? 'Unknown',
 		referer_id: cart.visitorRefererId ?? visitor?.referer_id ?? 'Unknown',
+
 		isBot: visitor?.isBot ?? false,
 
 		href:
@@ -258,7 +259,7 @@ export async function recordCartEvent({
 			await reportEventToMeta({
 				pixelId: metaPixel.id,
 				accessToken: metaPixel.accessToken,
-				url: visitorInfo.href,
+				sourceUrl: visitorInfo.referer_url ?? '', // this is an api route, so we want the source of the api call
 				ip: visitorInfo.ip,
 				ua: visitorInfo.userAgent.ua,
 				geo: visitorInfo.geo,
@@ -590,7 +591,7 @@ export async function recordFmEvent({
 			await reportEventToMeta({
 				pixelId: metaPixel.id,
 				accessToken: metaPixel.accessToken,
-				url: visitor?.href ?? '',
+				sourceUrl: visitor?.referer_url ?? '', // this is being logged from an api route
 				ip: visitor?.ip,
 				ua: visitor?.userAgent.ua,
 				geo: visitor?.geo,

--- a/packages/lib/utils/middleware.ts
+++ b/packages/lib/utils/middleware.ts
@@ -62,13 +62,6 @@ export function parseReferer(req: NextRequest) {
 
 export const visitorInfoSchema = z.object({
 	ip: z.string(),
-	// geo: nextGeoSchema.required({
-	// 	latitude: true,
-	// 	longitude: true,
-	// 	city: true,
-	// 	country: true,
-	// 	region: true,
-	// }),
 	geo: nextGeoSchema,
 	userAgent: formattedUserAgentSchema,
 	isBot: z.boolean(),


### PR DESCRIPTION
- made the input prop 'sourceUrl' to be clearer about what we're looking for. in the case of .fm or .cart logging, it'd be the referer_url since the event logging is occuring in an api route (i.e. we want the url of the client calling the api). in the case of .link logging, the logging occurs in the middleware, so the sourceUrl is the href
- added fbc to metaEvent reporting