### PR TITLE
added some nice-to-have features to barely.fm

### DIFF
--- a/apps/app/next.config.mjs
+++ b/apps/app/next.config.mjs
@@ -27,6 +27,11 @@ const config = {
 			},
 			{
 				protocol: 'https',
+				hostname: 'image-cdn-ak.spotifycdn.com',
+				pathname: '/**',
+			},
+			{
+				protocol: 'https',
 				hostname: 'res.cloudinary.com',
 				pathname: '/**',
 			},

--- a/apps/app/src/app/[handle]/settings/apps/page.tsx
+++ b/apps/app/src/app/[handle]/settings/apps/page.tsx
@@ -13,6 +13,7 @@ const IntegrationsPage = () => {
 			<DashContentHeader title='Accounts' subtitle='Connect your external accounts' />
 			<ProviderAccountCard provider='mailchimp' />
 			<ProviderAccountCard provider='tiktok' />
+			<ProviderAccountCard provider='spotify' />
 		</>
 	);
 };

--- a/apps/app/src/app/[handle]/settings/apps/provider-account-card.tsx
+++ b/apps/app/src/app/[handle]/settings/apps/provider-account-card.tsx
@@ -49,7 +49,7 @@ export const ProviderAccountCard = ({ provider }: ExternalAccountCardProps) => {
 			provider,
 			providerAccountId: accountId,
 		});
-		return utils.providerAccount.byCurrentUser.invalidate();
+		return utils.providerAccount.invalidate();
 	};
 
 	const platform = toTitleCase(provider);
@@ -71,6 +71,9 @@ export const ProviderAccountCard = ({ provider }: ExternalAccountCardProps) => {
 										{account.username ?? account.providerAccountId}
 									</p>
 									<p className='text-sm text-muted-foreground'>{account.email}</p>
+									<p className='text-sm text-muted-foreground'>
+										{account.providerAccountId}
+									</p>
 								</div>
 
 								<AlertDialog

--- a/apps/app/src/app/[handle]/settings/socials/social-settings.tsx
+++ b/apps/app/src/app/[handle]/settings/socials/social-settings.tsx
@@ -4,10 +4,10 @@ import { useWorkspaceUpdateForm } from '@barely/lib/hooks/use-workspace-update-f
 import {
 	isValidUrl,
 	parseInstagramLink,
-	parseSpotifyLink,
 	parseTikTokLink,
 	parseYoutubeLink,
 } from '@barely/lib/utils/link';
+import { parseSpotifyUrl } from '@barely/lib/utils/spotify';
 
 import { SettingsCardForm } from '@barely/ui/components/settings-card';
 import { NumberField } from '@barely/ui/forms/number-field';
@@ -83,7 +83,7 @@ export function SocialLinksForm() {
 				onPaste={e => {
 					const input = e.clipboardData.getData('text');
 					if (!input || !isValidUrl(input)) return;
-					const parsedSpotifyLink = parseSpotifyLink(input);
+					const parsedSpotifyLink = parseSpotifyUrl(input);
 					if (!parsedSpotifyLink || parsedSpotifyLink.type !== 'artist') return;
 					e.preventDefault();
 					form.setValue('spotifyArtistId', parsedSpotifyLink.id, { shouldDirty: true });

--- a/apps/app/src/app/[handle]/tracks/_components/create-or-update-track-modal.tsx
+++ b/apps/app/src/app/[handle]/tracks/_components/create-or-update-track-modal.tsx
@@ -15,7 +15,7 @@ import {
 	formatWorkspaceTrackToUpsertTrackForm,
 	upsertTrackSchema,
 } from '@barely/lib/server/routes/track/track.schema';
-import { parseSpotifyLink } from '@barely/lib/utils/link';
+import { parseSpotifyUrl } from '@barely/lib/utils/spotify';
 import { atom } from 'jotai';
 
 import { Badge } from '@barely/ui/elements/badge';
@@ -222,7 +222,7 @@ export function CreateOrUpdateTrackModal(props: { mode: 'create' | 'update' }) {
 						label='Spotify ID'
 						onPaste={e => {
 							const input = e.clipboardData.getData('text');
-							const parsed = parseSpotifyLink(input);
+							const parsed = parseSpotifyUrl(input);
 							if (!input ?? parsed?.type !== 'track') return;
 							e.preventDefault();
 							form.setValue('spotifyId', parsed.id);

--- a/apps/app/src/app/api/apps/callback/spotify/route.ts
+++ b/apps/app/src/app/api/apps/callback/spotify/route.ts
@@ -1,0 +1,95 @@
+import { auth } from '@barely/lib/server/auth';
+import { dbHttp } from '@barely/lib/server/db';
+import { providerStateSchema } from '@barely/lib/server/routes/provider-account/provider-account.schema';
+import { ProviderAccounts } from '@barely/lib/server/routes/provider-account/provider-account.sql';
+import { newId } from '@barely/lib/utils/id';
+import { raise } from '@barely/lib/utils/raise';
+import { getAbsoluteUrl } from '@barely/lib/utils/url';
+import { z } from 'zod';
+
+export const GET = auth(async req => {
+	const params = req.nextUrl.searchParams;
+	const code = params.get('code') ?? raise('code is required');
+	// const state = params.get('state') ?? raise('state is required');
+
+	console.log('code', code);
+
+	const base64EncodedState = params.get('state') ?? raise('state is required');
+	const base64DecodedState = Buffer.from(base64EncodedState, 'base64').toString('utf-8');
+	console.log('base64DecodedState', base64DecodedState);
+	const state = providerStateSchema.parse(JSON.parse(base64DecodedState));
+	console.log('state', state);
+
+	const userId = req.auth?.user.id;
+	if (!userId) {
+		return new Response('user not found', { status: 404 });
+	}
+
+	const workspace = req.auth?.user.workspaces.find(
+		workspace => workspace.id === state.workspaceId,
+	);
+
+	if (!workspace) {
+		return new Response('workspace not found', { status: 404 });
+	}
+
+	const tokenRes = await fetch('https://accounts.spotify.com/api/token', {
+		method: 'POST',
+		headers: {
+			Authorization: `Basic ${Buffer.from(`${process.env.SPOTIFY_CLIENT_ID}:${process.env.SPOTIFY_CLIENT_SECRET}`).toString('base64')}`,
+			'Content-Type': 'application/x-www-form-urlencoded',
+		},
+		body: new URLSearchParams({
+			grant_type: 'authorization_code',
+			code,
+			redirect_uri: getAbsoluteUrl('app', 'api/apps/callback/spotify'),
+		}),
+	});
+
+	const token = spotifyTokenSchema.parse(await tokenRes.json());
+	console.log('token', token);
+
+	// get user information
+	const userRes = await fetch('https://api.spotify.com/v1/me', {
+		headers: {
+			Authorization: `Bearer ${token.access_token}`,
+		},
+	});
+	const user = spotifyUserSchema.parse(await userRes.json());
+	console.log('user', user);
+
+	await dbHttp.insert(ProviderAccounts).values({
+		provider: 'spotify',
+		id: newId('providerAccount'),
+		userId,
+		workspaceId: workspace.id,
+		type: 'oauth',
+
+		access_token: token.access_token,
+		refresh_token: token.refresh_token,
+		expires_at: Math.floor(Date.now() / 1000 + token.expires_in), //
+		scope: token.scope,
+
+		providerAccountId: user.id,
+		username: user.display_name,
+		email: user.email,
+		image: user.images[0]?.url,
+	});
+
+	return Response.redirect(state.redirectUrl);
+});
+
+const spotifyTokenSchema = z.object({
+	access_token: z.string(),
+	token_type: z.literal('Bearer'),
+	scope: z.string(),
+	expires_in: z.number().int(),
+	refresh_token: z.string(),
+});
+
+const spotifyUserSchema = z.object({
+	id: z.string(),
+	display_name: z.string(),
+	email: z.string().email(),
+	images: z.array(z.object({ url: z.string() })),
+});

--- a/apps/fm/src/app/[handle]/[...key]/fm-link-button.tsx
+++ b/apps/fm/src/app/[handle]/[...key]/fm-link-button.tsx
@@ -2,6 +2,8 @@
 
 import type { FmLink } from '@barely/lib/server/routes/fm/fm.schema';
 import { fmPageApi } from '@barely/lib/server/routes/fm-page/fm-page.api.react';
+import { isValidUrl } from '@barely/lib/utils/link';
+import { getSpotifyPlaylistTrackDeeplink } from '@barely/lib/utils/spotify';
 
 import { Button } from '@barely/ui/elements/button';
 import { Img } from '@barely/ui/elements/img';
@@ -12,6 +14,23 @@ export const FmLinkButton = ({ link }: { link: FmLink }) => {
 	const { mutate: logEvent } = fmPageApi.log.useMutation();
 
 	const label = link.platform === 'itunes' ? 'BUY' : 'PLAY';
+
+	const isSpotifyPlaylist =
+		link.platform === 'spotify' && link.url.includes('spotify.com/playlist');
+	const hasSpotifyTrackUrl = !!link.spotifyTrackUrl && isValidUrl(link.spotifyTrackUrl);
+	// set href with a switch statement
+	let href = link.url;
+	switch (true) {
+		case isSpotifyPlaylist && hasSpotifyTrackUrl && !!link.spotifyTrackUrl:
+			href =
+				getSpotifyPlaylistTrackDeeplink({
+					playlistUrl: link.url,
+					trackUrl: link.spotifyTrackUrl,
+				}) ?? link.url;
+			break;
+		default:
+			break;
+	}
 
 	return (
 		<div className='flex flex-row items-center justify-between gap-4'>
@@ -28,7 +47,7 @@ export const FmLinkButton = ({ link }: { link: FmLink }) => {
 			<Button
 				look='outline'
 				className='min-w-[100px] border-foreground/40 text-foreground/60 hover:border-foreground hover:text-foreground sm:min-w-[150px] md:text-sm'
-				href={link.url}
+				href={href}
 				target='_blank'
 				rel='noopener noreferrer'
 				onClick={() => {

--- a/packages/lib/files/upload-from-url.ts
+++ b/packages/lib/files/upload-from-url.ts
@@ -1,0 +1,41 @@
+import type { ACL } from '@uploadthing/shared';
+import { PutObjectCommand } from '@aws-sdk/client-s3';
+
+import { env } from '../env';
+import { s3 } from './s3';
+
+export async function uploadFileFromUrl({
+	url,
+	key,
+	acl = 'public-read',
+	contentDisposition = 'inline',
+}: {
+	url: string;
+	key: string;
+	acl?: ACL;
+	contentDisposition?: 'inline' | 'attachment';
+}) {
+	// fetch the file
+	const res = await fetch(url);
+	const fileBuffer = await res.arrayBuffer();
+	const buffer = Buffer.from(fileBuffer);
+
+	// upload the file
+	const command = new PutObjectCommand({
+		Bucket: env.AWS_S3_BUCKET_NAME,
+		Key: key,
+		Body: buffer,
+		ContentType: res.headers.get('content-type') ?? undefined,
+		ContentDisposition: contentDisposition,
+		ACL: acl,
+	});
+
+	await s3.send(command);
+
+	const fileSize = buffer.length;
+
+	return {
+		src: `https://${env.AWS_S3_BUCKET_NAME}.s3.amazonaws.com/${key}`,
+		fileSize,
+	};
+}

--- a/packages/lib/server/routes/cart/cart.sql.ts
+++ b/packages/lib/server/routes/cart/cart.sql.ts
@@ -261,7 +261,7 @@ export const CartFulfillmentProducts = pgTable(
 	'CartFulfillmentProducts',
 	{
 		// cartId: dbId('cartId').references(() => Carts.id),
-		cartFulfillmentId: dbId('cartFulfillmentId').references(() => CartFulfillments.id),
+		cartFulfillmentId: dbId('cartFulfillmentsId').references(() => CartFulfillments.id),
 		productId: dbId('productId').references(() => Products.id),
 	},
 	product => ({

--- a/packages/lib/server/routes/cart/cart.sql.ts
+++ b/packages/lib/server/routes/cart/cart.sql.ts
@@ -261,7 +261,7 @@ export const CartFulfillmentProducts = pgTable(
 	'CartFulfillmentProducts',
 	{
 		// cartId: dbId('cartId').references(() => Carts.id),
-		cartFulfillmentId: dbId('cartFulfillmentsId').references(() => CartFulfillments.id),
+		cartFulfillmentId: dbId('cartFulfillmentId').references(() => CartFulfillments.id),
 		productId: dbId('productId').references(() => Products.id),
 	},
 	product => ({

--- a/packages/lib/server/routes/cart/cart.sql.ts
+++ b/packages/lib/server/routes/cart/cart.sql.ts
@@ -266,7 +266,7 @@ export const CartFulfillmentProducts = pgTable(
 	},
 	product => ({
 		pk: primaryKey({
-			name: 'CartFulfillment_Products_pk',
+			name: 'CartFulfillment_Product_pk',
 			columns: [product.cartFulfillmentId, product.productId],
 		}),
 		// cart_product: uniqueIndex('cart_product_unique').on(

--- a/packages/lib/server/routes/cart/cart.sql.ts
+++ b/packages/lib/server/routes/cart/cart.sql.ts
@@ -266,7 +266,7 @@ export const CartFulfillmentProducts = pgTable(
 	},
 	product => ({
 		pk: primaryKey({
-			name: 'CartFulfillment_Product_pk',
+			name: 'Fulfill_Product_pk',
 			columns: [product.cartFulfillmentId, product.productId],
 		}),
 		// cart_product: uniqueIndex('cart_product_unique').on(

--- a/packages/lib/server/routes/file/file.router.ts
+++ b/packages/lib/server/routes/file/file.router.ts
@@ -70,6 +70,16 @@ export const fileRouter = createTRPCRouter({
 			};
 		}),
 
+	// uploadFileFromUrl: privateProcedure
+	//     .input(z.object({
+	//         fileUrl: z.string().url(),
+	//         folder: z.string(),
+	//     }))
+	//     .mutation(async ({ input, ctx }) => {
+	//         // fetch the file
+	//         const response = await
+	//     }),
+
 	getPresigned: privateProcedure
 		.input(
 			z.object({

--- a/packages/lib/server/routes/fm/fm.schema.ts
+++ b/packages/lib/server/routes/fm/fm.schema.ts
@@ -31,6 +31,8 @@ export const insertFmPageSchema = createInsertSchema(FmPages, {
 	key: s => s.key.min(4, 'Key is required'),
 	title: s => s.title.min(1, 'Title is required'),
 	sourceUrl: s => s.sourceUrl.min(1, 'Source URL is required'),
+}).extend({
+	coverArtUrl: z.string().optional(),
 });
 
 export const createFmPageSchema = insertFmPageSchema

--- a/packages/lib/server/routes/fm/fm.sql.ts
+++ b/packages/lib/server/routes/fm/fm.sql.ts
@@ -79,6 +79,7 @@ export const FmLinks = pgTable('FmLinks', {
 		enum: FM_LINK_PLATFORMS,
 	}).notNull(),
 	url: varchar('url', { length: 255 }).notNull(),
+	spotifyTrackUrl: varchar('spotifyTrackUrl', { length: 255 }),
 	customPlatformName: varchar('customPlatformName', { length: 255 }),
 	customButtonTextColor: varchar('customButtonTextColor', { length: 255 }),
 	clicks: integer('clicks').default(0),

--- a/packages/lib/server/routes/provider-account/provider-account.router.ts
+++ b/packages/lib/server/routes/provider-account/provider-account.router.ts
@@ -104,6 +104,27 @@ const providerAccountRouter = createTRPCRouter({
 				return mailchimpAuthorization.toString();
 			}
 
+			if (provider === 'spotify') {
+				const spotifyAuthorization = new URL('https://accounts.spotify.com/authorize');
+				spotifyAuthorization.searchParams.set('client_id', env.SPOTIFY_CLIENT_ID);
+				spotifyAuthorization.searchParams.set('response_type', 'code');
+				const redirectUri = getAbsoluteUrl('app', `api/apps/callback/spotify`);
+				console.log('redirectUri', redirectUri);
+				spotifyAuthorization.searchParams.set(
+					'redirect_uri',
+					getAbsoluteUrl('app', `api/apps/callback/spotify`),
+				);
+				spotifyAuthorization.searchParams.set('state', base64EncodedState);
+				spotifyAuthorization.searchParams.set(
+					'scope',
+					'ugc-image-upload,user-modify-playback-state,user-read-playback-state,user-modify-playback-state,user-read-currently-playing,user-follow-modify,user-follow-read,user-read-recently-played,user-read-playback-position,user-top-read,playlist-read-collaborative,playlist-modify-public,playlist-read-private,playlist-modify-private,app-remote-control,streaming,user-read-email,user-read-private,user-library-modify,user-library-read',
+				);
+				spotifyAuthorization.searchParams.set('show_dialog', 'true');
+				const authUrl = spotifyAuthorization.toString();
+				console.log('authUrl', authUrl);
+				return authUrl;
+			}
+
 			return null;
 		}),
 });

--- a/packages/lib/server/routes/provider-account/provider-account.sql.ts
+++ b/packages/lib/server/routes/provider-account/provider-account.sql.ts
@@ -46,7 +46,7 @@ export const ProviderAccounts = pgTable(
 		// token management
 		refresh_token: varchar('refresh_token', { length: 2000 }),
 		access_token: varchar('access_token', { length: 2000 }),
-		expires_at: integer('expires_at'),
+		expires_at: integer('expires_at'), // unix timestamp in seconds
 		token_type: varchar('token_type', { length: 255 }),
 		scope: varchar('scope', { length: 2000 }),
 		id_token: varchar('id_token', { length: 255 }),

--- a/packages/lib/server/routes/spotify/spotify.router.ts
+++ b/packages/lib/server/routes/spotify/spotify.router.ts
@@ -5,8 +5,13 @@ import { z } from 'zod';
 
 import type { SpotifyTrackOption } from './spotify.schema';
 import { env } from '../../../env';
+import { parseSpotifyUrl } from '../../../utils/spotify';
 import { createTRPCRouter, privateProcedure, publicProcedure } from '../../api/trpc';
+import { getSpotifyAlbum } from '../../spotify/spotify.endpts.album';
+import { getSpotifyArtist } from '../../spotify/spotify.endpts.artist';
+import { getSpotifyPlaylist } from '../../spotify/spotify.endpts.playlist';
 import { searchSpotify } from '../../spotify/spotify.endpts.search';
+import { getSpotifyTrack } from '../../spotify/spotify.endpts.track';
 import { ProviderAccounts } from '../provider-account/provider-account.sql';
 import {
 	getSpotifyAccessToken,
@@ -15,6 +20,127 @@ import {
 } from './spotify.fns';
 
 const spotifyRouter = createTRPCRouter({
+	getImageUrl: publicProcedure
+		.input(
+			z.object({
+				query: z.string(),
+			}),
+		)
+		.query(async ({ input, ctx }) => {
+			const parsedItem = parseSpotifyUrl(input.query);
+			console.log('parsedItem => ', parsedItem);
+			if (!parsedItem) return null;
+			const { type, id } = parsedItem;
+
+			if (!type || !id) return null;
+
+			const botSpotifyAccount = await ctx.db.http.query.ProviderAccounts.findFirst({
+				where: and(
+					eq(ProviderAccounts.provider, 'spotify'),
+					eq(ProviderAccounts.providerAccountId, env.BOT_SPOTIFY_ACCOUNT_ID),
+				),
+			});
+
+			if (!botSpotifyAccount) {
+				throw new TRPCError({
+					code: 'INTERNAL_SERVER_ERROR',
+					message: "We're having trouble with the Spotify API right now. Bear with us.",
+					cause: 'No bot Spotify account found.',
+				});
+			}
+
+			const accessToken = await getSpotifyAccessToken(botSpotifyAccount);
+
+			if (!accessToken) {
+				throw new TRPCError({
+					code: 'INTERNAL_SERVER_ERROR',
+					message: "We're having trouble with the Spotify API right now. Bear with us.",
+					cause: 'No Spotify access token found for bot.',
+				});
+			}
+
+			if (type === 'playlist') {
+				const playlist = await getSpotifyPlaylist({
+					accessToken,
+					spotifyId: id,
+				});
+
+				console.log('playlist => ', playlist);
+
+				return playlist?.images[0]?.url ?? null;
+			} else if (type === 'track') {
+				const track = await getSpotifyTrack({
+					accessToken,
+					spotifyId: id,
+				});
+
+				console.log('track => ', track);
+
+				return track?.album?.images[0]?.url ?? null;
+			} else if (type === 'album') {
+				const album = await getSpotifyAlbum({
+					accessToken,
+					spotifyId: id,
+				});
+
+				console.log('album => ', album);
+
+				return album?.images[0]?.url ?? null;
+			} else if (type === 'artist') {
+				const artist = await getSpotifyArtist({
+					accessToken,
+					spotifyId: id,
+				});
+
+				console.log('artist => ', artist);
+
+				return artist?.images[0]?.url ?? null;
+			}
+
+			return null;
+		}),
+	search: publicProcedure
+		.input(
+			z.object({
+				query: z.string(),
+				limit: z.number().optional(),
+			}),
+		)
+		.query(async ({ ctx, input }) => {
+			const botSpotifyAccount = await ctx.db.http.query.ProviderAccounts.findFirst({
+				where: and(
+					eq(ProviderAccounts.provider, 'spotify'),
+					eq(ProviderAccounts.providerAccountId, env.BOT_SPOTIFY_ACCOUNT_ID),
+				),
+			});
+
+			if (!botSpotifyAccount) {
+				throw new TRPCError({
+					code: 'INTERNAL_SERVER_ERROR',
+					message: "We're having trouble with the Spotify API right now. Bear with us.",
+					cause: 'No bot Spotify account found.',
+				});
+			}
+
+			const accessToken = await getSpotifyAccessToken(botSpotifyAccount);
+
+			if (!accessToken) {
+				throw new TRPCError({
+					code: 'INTERNAL_SERVER_ERROR',
+					message: "We're having trouble with the Spotify API right now. Bear with us.",
+					cause: 'No Spotify access token found for bot.',
+				});
+			}
+
+			const searchResults = await searchSpotify({
+				accessToken,
+				query: input.query,
+				limit: input.limit,
+			});
+
+			return searchResults;
+		}),
+
 	findTrack: publicProcedure.input(z.string()).query(async ({ ctx, input }) => {
 		if (input.length === 0) return [];
 

--- a/packages/lib/server/spotify/spotify.endpts.album.ts
+++ b/packages/lib/server/spotify/spotify.endpts.album.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+
+import { zGet } from '../../utils/zod-fetch';
+
+export async function getSpotifyAlbum(props: { accessToken: string; spotifyId: string }) {
+	const endpoint = `https://api.spotify.com/v1/albums/${props.spotifyId}`;
+
+	const auth = `Bearer ${props.accessToken}`;
+
+	const res = await zGet(endpoint, spotifyAlbumResponseSchema, { auth });
+
+	if (!res.success || !res.parsed) return null;
+
+	return res.data;
+}
+
+const spotifyAlbumResponseSchema = z.object({
+	album_type: z.string(),
+	artists: z.array(
+		z.object({
+			external_urls: z.object({
+				spotify: z.string(),
+			}),
+			href: z.string(),
+			id: z.string(),
+			name: z.string(),
+			type: z.string(),
+			uri: z.string(),
+		}),
+	),
+	available_markets: z.array(z.string()),
+	external_urls: z.object({
+		spotify: z.string(),
+	}),
+	href: z.string(),
+	id: z.string(),
+	images: z.array(
+		z.object({
+			url: z.string(),
+			height: z.number().nullable(),
+			width: z.number().nullable(),
+		}),
+	),
+	name: z.string(),
+	release_date: z.string(),
+	release_date_precision: z.string(),
+	total_tracks: z.number(),
+	type: z.string(),
+	uri: z.string(),
+	tracks: z.object({
+		items: z.array(
+			z.object({
+				artists: z.array(
+					z.object({
+						external_urls: z.object({
+							spotify: z.string(),
+						}),
+						href: z.string(),
+						id: z.string(),
+						name: z.string(),
+						type: z.string(),
+						uri: z.string(),
+					}),
+				),
+				available_markets: z.array(z.string()),
+				disc_number: z.number(),
+				duration_ms: z.number(),
+				explicit: z.boolean(),
+				external_urls: z.object({
+					spotify: z.string(),
+				}),
+				href: z.string(),
+				id: z.string(),
+				is_local: z.boolean(),
+				name: z.string(),
+				preview_url: z.string().optional(),
+				track_number: z.number().nullish(),
+				type: z.string(),
+				uri: z.string(),
+			}),
+		),
+	}),
+});
+
+export { spotifyAlbumResponseSchema };

--- a/packages/lib/server/spotify/spotify.endpts.artist.ts
+++ b/packages/lib/server/spotify/spotify.endpts.artist.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+
+import { zGet } from '../../utils/zod-fetch';
+
+export async function getSpotifyArtist(props: {
+	accessToken: string;
+	spotifyId: string;
+}) {
+	const endpoint = `https://api.spotify.com/v1/artists/${props.spotifyId}`;
+
+	const auth = `Bearer ${props.accessToken}`;
+
+	const res = await zGet(endpoint, spotifyArtistResponseSchema, { auth });
+
+	if (!res.success || !res.parsed) return null;
+
+	return res.data;
+}
+
+const spotifyArtistResponseSchema = z.object({
+	external_urls: z.object({
+		spotify: z.string(),
+	}),
+	followers: z.object({
+		href: z.string().nullable(),
+		total: z.number(),
+	}),
+	genres: z.array(z.string()),
+	href: z.string(),
+	id: z.string(),
+	images: z.array(
+		z.object({
+			url: z.string(),
+			height: z.number().nullable(),
+			width: z.number().nullable(),
+		}),
+	),
+	name: z.string(),
+	popularity: z.number(),
+	type: z.string(),
+	uri: z.string(),
+});
+
+export { spotifyArtistResponseSchema };

--- a/packages/lib/server/spotify/spotify.endpts.playlist.ts
+++ b/packages/lib/server/spotify/spotify.endpts.playlist.ts
@@ -9,7 +9,12 @@ const getSpotifyPlaylist = async (props: { accessToken: string; spotifyId: strin
 	const endpoint = `https://api.spotify.com/v1/playlists/${props.spotifyId}`;
 	const auth = `Bearer ${props.accessToken}`;
 	const response = await zGet(endpoint, getPlaylistResponseSchema, { auth });
-	return response;
+
+	console.log('response => ', response.data);
+
+	if (!response.success || !response.parsed) return null;
+
+	return response.data;
 };
 
 const getSpotifyUserPlaylists = async (props: {
@@ -161,8 +166,8 @@ const getPlaylistResponseSchema = z.object({
 	name: z.string(),
 	description: z.string(),
 	followers: z.object({
-		href: z.string(),
-		total: z.number(),
+		href: z.string().nullable(),
+		total: z.number().int(),
 	}),
 	images: z.array(
 		z.object({

--- a/packages/lib/server/spotify/spotify.endpts.search.ts
+++ b/packages/lib/server/spotify/spotify.endpts.search.ts
@@ -11,10 +11,10 @@ interface SpotifySearchProps {
 	limit?: number;
 }
 
-const searchSpotify = async (props: SpotifySearchProps) => {
-	// console.log('searching spotify');
+export async function searchSpotify(props: SpotifySearchProps) {
 	const query = props.query;
-	const types = props.types ? props.types.join(',') : '';
+	const types = props.types ? props.types.join(',') : 'artist,album,track,playlist';
+
 	const limit = props.limit ?? 20;
 
 	const endpoint = `https://api.spotify.com/v1/search?q=${query}&type=${types}&limit=${limit}`;
@@ -24,13 +24,17 @@ const searchSpotify = async (props: SpotifySearchProps) => {
 		auth,
 	});
 
-	if (!searchResponse.success) throw new Error('Error searching Spotify.');
-	if (!searchResponse.parsed) throw new Error('Error parsing Spotify search response.');
+	if (!searchResponse.success) {
+		console.log('searchResponse.data error', searchResponse.data);
+		throw new Error('Error searching Spotify.', { cause: searchResponse.data });
+	}
+	if (!searchResponse.parsed)
+		throw new Error('Error parsing Spotify search response.', {
+			cause: searchResponse.data,
+		});
 
 	return searchResponse.data;
-};
-
-export { searchSpotify };
+}
 
 //* 📓 SCHEMA 📓 *//
 

--- a/packages/lib/server/spotify/spotify.endpts.track.ts
+++ b/packages/lib/server/spotify/spotify.endpts.track.ts
@@ -1,5 +1,19 @@
 import { z } from 'zod';
 
+import { zGet } from '../../utils/zod-fetch';
+
+export async function getSpotifyTrack(props: { accessToken: string; spotifyId: string }) {
+	const endpoint = `https://api.spotify.com/v1/tracks/${props.spotifyId}`;
+
+	const auth = `Bearer ${props.accessToken}`;
+
+	const res = await zGet(endpoint, spotifyTrackResponseSchema, { auth });
+
+	if (!res.success || !res.parsed) return null;
+
+	return res.data;
+}
+
 const spotifyTrackResponseSchema = z.object({
 	album: z.object({
 		album_type: z.string(),

--- a/packages/lib/utils/id.ts
+++ b/packages/lib/utils/id.ts
@@ -35,6 +35,7 @@ const prefixes = {
 	fmPage: 'fm',
 	fmLink: 'fml',
 	fmSession: 'fms',
+	fmCoverArt: 'fmca',
 	// forms
 	form: 'form',
 	formResponse: 'form_res',

--- a/packages/lib/utils/link.ts
+++ b/packages/lib/utils/link.ts
@@ -11,20 +11,20 @@ import {
 	SPECIAL_APEX_DOMAINS,
 } from './constants';
 
-export function parseSpotifyLink(link: string) {
-	const match = link.match(
-		/https?:\/\/open\.spotify\.com\/(artist|track|album|playlist)\/([a-zA-Z0-9]+)/,
-	);
+// export function parseSpotifyLink(link: string) {
+// 	const match = link.match(
+// 		/https?:\/\/open\.spotify\.com\/(artist|track|album|playlist)\/([a-zA-Z0-9]+)/,
+// 	);
 
-	if (!match) {
-		return null;
-	}
+// 	if (!match) {
+// 		return null;
+// 	}
 
-	return {
-		type: match[1],
-		id: match[2],
-	};
-}
+// 	return {
+// 		type: match[1],
+// 		id: match[2],
+// 	};
+// }
 
 export function parseInstagramLink(link: string) {
 	const match = link.match(/https?:\/\/(?:www\.)?instagram\.com\/([^/?]+)/);

--- a/packages/lib/utils/spotify.ts
+++ b/packages/lib/utils/spotify.ts
@@ -1,0 +1,35 @@
+export function getSpotifyPlaylistTrackDeeplink({
+	playlistUrl,
+	trackUrl,
+}: {
+	playlistUrl: string;
+	trackUrl: string;
+}) {
+	// we have a playlist url in this format: https://open.spotify.com/playlist/4mW0Wo6gMrE0K8iALUCByK?si=26c13373e28944b8
+	// we have a track url in this format: https://open.spotify.com/track/5nYrALRnMuqCeqXl2oK2qh?si=26c13373e28944b8
+	// we want to return a deeplink in this format: https://open.spotify.com/track/5nYrALRnMuqCeqXl2oK2qh?context=spotify:playlist:4mW0Wo6gMrE0K8iALUCByK?si=
+
+	const parsedPlaylistLink = parseSpotifyUrl(playlistUrl);
+	const parsedTrackLink = parseSpotifyUrl(trackUrl);
+
+	if (!parsedPlaylistLink || !parsedTrackLink) {
+		return null;
+	}
+
+	return `https://open.spotify.com/track/${parsedTrackLink.id}?context=spotify:playlist:${parsedPlaylistLink.id}`;
+}
+
+export function parseSpotifyUrl(url: string) {
+	const match = url.match(
+		/https?:\/\/open\.spotify\.com\/(artist|track|album|playlist)\/([a-zA-Z0-9]+)/,
+	);
+
+	if (!match) {
+		return null;
+	}
+
+	return {
+		type: match[1],
+		id: match[2],
+	};
+}

--- a/packages/ui/elements/alert-dialog.tsx
+++ b/packages/ui/elements/alert-dialog.tsx
@@ -37,7 +37,9 @@ const AlertDialogOverlay = React.forwardRef<
 	// >(({ className, children, ...props }, ref) => (
 	<AlertDialogPrimitive.Overlay
 		className={cn(
-			'fixed inset-0 z-50 bg-background/80 backdrop-blur-sm transition-opacity animate-in fade-in',
+			'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+
+			// 'fixed inset-0 z-50 bg-background/80 backdrop-blur-sm transition-opacity animate-in fade-in',
 			className,
 		)}
 		{...props}
@@ -55,7 +57,9 @@ const AlertDialogContent = React.forwardRef<
 		<AlertDialogPrimitive.Content
 			ref={ref}
 			className={cn(
-				'fixed z-50 grid w-full max-w-lg scale-100 gap-4 border bg-background p-6 opacity-100 animate-in fade-in-90 slide-in-from-bottom-10 sm:rounded-lg sm:zoom-in-90 sm:slide-in-from-bottom-0 md:w-full',
+				'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+
+				// 'fixed z-50 grid w-full max-w-lg scale-100 gap-4 border bg-background p-6 opacity-100 animate-in fade-in-90 slide-in-from-bottom-10 sm:rounded-lg sm:zoom-in-90 sm:slide-in-from-bottom-0 md:w-full',
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
- get image from spotify source url (track, album, playlist, artist)
- if spotify source url, auto-populate spotify link below
- add track deeplink option for spotify playlist fm link
- re-added ability to add spotify account
- upload file from url to s3 (needed for added spotify link to barely file storage)
- fixed alert-dialog issue w/ updated radix
- added spotify.artist, .track, .album endpoints (needed for search)