### PR TITLE
init Resend events (webhook + SQL + handle logic)

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -54,6 +54,7 @@
 		"remeda": "^1.24.0",
 		"sharp": "^0.33.2",
 		"superjson": "^2.2.1",
+		"svix": "^1.35.0",
 		"tailwindcss-animate": "^1.0.7",
 		"trpc-openapi": "^1.2.0",
 		"zod": "^3.23.8",

--- a/apps/app/src/app/[handle]/settings/email/domains/_components/create-or-update-email-domain-modal.tsx
+++ b/apps/app/src/app/[handle]/settings/email/domains/_components/create-or-update-email-domain-modal.tsx
@@ -10,6 +10,7 @@ import { cn } from '@barely/lib/utils/cn';
 import { Icon } from '@barely/ui/elements/icon';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '@barely/ui/elements/modal';
 import { Form, SubmitButton } from '@barely/ui/forms';
+import { SwitchField } from '@barely/ui/forms/switch-field';
 import { TextField } from '@barely/ui/forms/text-field';
 
 import { useEmailDomainContext } from '~/app/[handle]/settings/email/domains/_components/email-domain-context';
@@ -129,6 +130,18 @@ export function CreateOrUpdateEmailDomainModal({ mode }: { mode: 'create' | 'upd
 						disabled={mode === 'update' && selectedEmailDomain && domainInputLocked}
 						placeholder='hello.example.com'
 						infoTooltip='This is the domain that will be used to send emails from.'
+					/>
+					<SwitchField
+						control={control}
+						name='openTracking'
+						label='Open Tracking'
+						infoTooltip='This will track opens on your emails.'
+					/>
+					<SwitchField
+						control={control}
+						name='clickTracking'
+						label='Click Tracking'
+						infoTooltip='This will track clicks on marketing links in your emails.'
 					/>
 				</ModalBody>
 				<ModalFooter>

--- a/apps/app/src/app/api/resend/route.ts
+++ b/apps/app/src/app/api/resend/route.ts
@@ -1,0 +1,34 @@
+import type { NextRequest } from 'next/server';
+import { handleEmailEvent } from '@barely/lib/server/routes/email-delivery/email-delivery.event-fns';
+import { Webhook } from 'svix';
+
+import { env } from '~/env';
+
+const secret = env.RESEND_WEBHOOK_SECRET;
+
+const wh = new Webhook(secret);
+
+export default async function POST(req: NextRequest) {
+	const body = await req.text();
+	// const payload = req.body;
+	// const headers = req.headers;
+	const svixId = req.headers.get('svix-id');
+	const svixTimestamp = req.headers.get('svix-timestamp');
+	const svixSignature = req.headers.get('svix-signature');
+
+	if (!svixId || !svixTimestamp || !svixSignature) {
+		return new Response('No svix headers', { status: 400 });
+	}
+
+	if (!body) {
+		return new Response('No payload or headers', { status: 400 });
+	}
+
+	const payload = wh.verify(body, {
+		'svix-id': svixId,
+		'svix-timestamp': svixTimestamp,
+		'svix-signature': svixSignature,
+	});
+
+	return await handleEmailEvent(payload);
+}

--- a/apps/app/src/env.ts
+++ b/apps/app/src/env.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 export const env = createEnv({
 	extends: [libEnv],
 	server: {
+		RESEND_WEBHOOK_SECRET: z.string(),
 		STRIPE_WEBHOOK_SECRET: z.string(),
 		STRIPE_CONNECT_WEBHOOK_SECRET: z.string(),
 	},

--- a/packages/lib/server/db/index.ts
+++ b/packages/lib/server/db/index.ts
@@ -22,8 +22,9 @@ import * as funnelSql from '../routes/cart-funnel/cart-funnel.sql';
 import * as cartSql from '../routes/cart/cart.sql';
 import * as domainSql from '../routes/domain/domain.sql';
 import * as emailAddressSql from '../routes/email-address/email-address.sql';
+import * as emailDeliverySql from '../routes/email-delivery/email-delivery.sql';
 import * as emailDomainSql from '../routes/email-domain/email-domain.sql';
-import * as emailSql from '../routes/email-template/email-template.sql';
+import * as emailTemplateSql from '../routes/email-template/email-template.sql';
 import * as eventReportSql from '../routes/event/event-report.sql';
 import * as eventSql from '../routes/event/event.sql';
 import * as externalWebsiteSql from '../routes/external-website/external-website.sql';
@@ -72,9 +73,10 @@ export const dbSchema = {
 	...campaignSql,
 	...cartSql,
 	...domainSql,
-	...emailSql,
 	...emailAddressSql,
 	...emailDomainSql,
+	...emailTemplateSql,
+	...emailDeliverySql,
 	...eventSql,
 	...eventReportSql,
 	...externalWebsiteSql,

--- a/packages/lib/server/routes/email-delivery/email-delivery.event-fns.ts
+++ b/packages/lib/server/routes/email-delivery/email-delivery.event-fns.ts
@@ -1,0 +1,78 @@
+import { eq } from 'drizzle-orm';
+
+import { dbHttp } from '../../db';
+import { emailEventSchema } from './email-delivery.schema';
+import { EmailDeliveries } from './email-delivery.sql';
+
+export async function handleEmailEvent(payload: unknown) {
+	const event = emailEventSchema.safeParse(payload);
+
+	if (!event.success) {
+		return new Response('Invalid event', { status: 400 });
+	}
+
+	const { type, data } = event.data;
+
+	switch (type) {
+		case 'email.bounced': {
+			const { email_id } = data;
+
+			await dbHttp
+				.update(EmailDeliveries)
+				.set({
+					bouncedAt: new Date(),
+				})
+				.where(eq(EmailDeliveries.resendId, email_id));
+
+			return new Response('Email bounced', { status: 200 });
+		}
+		case 'email.delivered': {
+			const { email_id } = data;
+
+			await dbHttp
+				.update(EmailDeliveries)
+				.set({
+					deliveredAt: new Date(),
+				})
+				.where(eq(EmailDeliveries.resendId, email_id));
+
+			return new Response('Email delivered', { status: 200 });
+		}
+		case 'email.opened': {
+			const { email_id } = data;
+
+			await dbHttp
+				.update(EmailDeliveries)
+				.set({
+					openedAt: new Date(),
+				})
+				.where(eq(EmailDeliveries.resendId, email_id));
+
+			return new Response('Email opened', { status: 200 });
+		}
+		case 'email.clicked': {
+			const { email_id } = data;
+
+			await dbHttp
+				.update(EmailDeliveries)
+				.set({
+					clickedAt: new Date(),
+				})
+				.where(eq(EmailDeliveries.resendId, email_id));
+
+			return new Response('Email clicked', { status: 200 });
+		}
+		case 'email.complained': {
+			const { email_id } = data;
+
+			await dbHttp
+				.update(EmailDeliveries)
+				.set({
+					complainedAt: new Date(),
+				})
+				.where(eq(EmailDeliveries.resendId, email_id));
+
+			return new Response('Email complained', { status: 200 });
+		}
+	}
+}

--- a/packages/lib/server/routes/email-delivery/email-delivery.schema.ts
+++ b/packages/lib/server/routes/email-delivery/email-delivery.schema.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod';
+
+const emailBouncedSchema = z.object({
+	type: z.literal('email.bounced'),
+	created_at: z.coerce.date(),
+	data: z.object({
+		created_at: z.coerce.date(),
+		email_id: z.string(),
+		from: z.string(),
+		to: z.array(z.string()),
+		subject: z.string(),
+	}),
+});
+
+const emailDeliveredSchema = z.object({
+	type: z.literal('email.delivered'),
+	created_at: z.coerce.date(),
+	data: z.object({
+		created_at: z.coerce.date(),
+		email_id: z.string(),
+		from: z.string(),
+		to: z.array(z.string()),
+		subject: z.string(),
+	}),
+});
+
+const emailOpenedSchema = z.object({
+	type: z.literal('email.opened'),
+	created_at: z.coerce.date(),
+	data: z.object({
+		created_at: z.coerce.date(),
+		email_id: z.string(),
+		from: z.string(),
+		to: z.array(z.string()),
+		subject: z.string(),
+	}),
+});
+
+const emailClickedSchema = z.object({
+	type: z.literal('email.clicked'),
+	created_at: z.coerce.date(),
+	data: z.object({
+		created_at: z.coerce.date(),
+		email_id: z.string(),
+		from: z.string(),
+		to: z.array(z.string()),
+		subject: z.string(),
+		click: z.object({
+			ipAddress: z.string(),
+			link: z.string(),
+			timestamp: z.coerce.date(),
+			userAgent: z.string(),
+		}),
+	}),
+});
+
+const emailComplainedSchema = z.object({
+	type: z.literal('email.complained'),
+	created_at: z.coerce.date(),
+	data: z.object({
+		created_at: z.coerce.date(),
+		email_id: z.string(),
+		from: z.string(),
+		to: z.array(z.string()),
+		subject: z.string(),
+	}),
+});
+
+export const emailEventSchema = z.union([
+	emailBouncedSchema,
+	emailOpenedSchema,
+	emailClickedSchema,
+	emailComplainedSchema,
+	emailDeliveredSchema,
+]);

--- a/packages/lib/server/routes/email-delivery/email-delivery.sql.ts
+++ b/packages/lib/server/routes/email-delivery/email-delivery.sql.ts
@@ -1,0 +1,61 @@
+import { relations } from 'drizzle-orm';
+import { pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+
+import { dbId, primaryId, timestamps } from '../../../utils/sql';
+import { EmailTemplates } from '../email-template/email-template.sql';
+import { Fans } from '../fan/fan.sql';
+import { Workspaces } from '../workspace/workspace.sql';
+
+export const EmailDeliveries = pgTable('EmailDeliveries', {
+	...primaryId,
+	...timestamps,
+	workspaceId: dbId('workspaceId')
+		.notNull()
+		.references(() => Workspaces.id),
+	emailTemplateId: dbId('emailTemplateId')
+		.notNull()
+		.references(() => EmailTemplates.id),
+
+	// delivery
+	resendId: text('resendId'),
+	fanId: dbId('fanId')
+		.notNull()
+		.references(() => Fans.id),
+	status: text('status', {
+		enum: [
+			'scheduled',
+			'sent',
+			'failed',
+			'delivered',
+			'opened',
+			'clicked',
+			'complained',
+			'bounced',
+			'unsubscribed',
+		],
+	}).notNull(),
+	scheduledAt: timestamp('scheduledAt'),
+	sentAt: timestamp('sentAt'),
+
+	deliveredAt: timestamp('deliveredAt'),
+	openedAt: timestamp('openedAt'),
+	bouncedAt: timestamp('bouncedAt'),
+	clickedAt: timestamp('clickedAt'),
+	complainedAt: timestamp('complainedAt'),
+	unsubscribedAt: timestamp('unsubscribedAt'),
+});
+
+export const EmailDeliveryRelations = relations(EmailDeliveries, ({ one }) => ({
+	emailTemplate: one(EmailTemplates, {
+		fields: [EmailDeliveries.emailTemplateId],
+		references: [EmailTemplates.id],
+	}),
+	workspace: one(Workspaces, {
+		fields: [EmailDeliveries.workspaceId],
+		references: [Workspaces.id],
+	}),
+	fan: one(Fans, {
+		fields: [EmailDeliveries.fanId],
+		references: [Fans.id],
+	}),
+}));

--- a/packages/lib/server/routes/email-domain/email-domain.sql.ts
+++ b/packages/lib/server/routes/email-domain/email-domain.sql.ts
@@ -1,6 +1,6 @@
 import type { Resend_DomainRecord } from '@barely/email';
 import { relations } from 'drizzle-orm';
-import { pgTable, text, varchar } from 'drizzle-orm/pg-core';
+import { boolean, pgTable, text, varchar } from 'drizzle-orm/pg-core';
 
 import { customJsonb, dbId, primaryId, timestamps } from '../../../utils/sql';
 import { Workspaces } from '../workspace/workspace.sql';
@@ -28,6 +28,9 @@ export const EmailDomains = pgTable('EmailDomains', {
 		.default('not_started'),
 
 	records: customJsonb<Resend_DomainRecord[]>('records').notNull().default([]),
+
+	clickTracking: boolean('clickTracking').notNull().default(false),
+	openTracking: boolean('openTracking').notNull().default(false),
 });
 
 export const EmailDomainRelations = relations(EmailDomains, ({ one }) => ({

--- a/packages/lib/server/routes/email-template/email-template.sql.ts
+++ b/packages/lib/server/routes/email-template/email-template.sql.ts
@@ -6,13 +6,12 @@ import {
 	pgTable,
 	primaryKey,
 	text,
-	timestamp,
 	unique,
 } from 'drizzle-orm/pg-core';
 
 import { dbId, primaryId, timestamps } from '../../../utils/sql';
 import { EmailAddresses } from '../email-address/email-address.sql';
-import { Fans } from '../fan/fan.sql';
+import { EmailDeliveries } from '../email-delivery/email-delivery.sql';
 import { Tags } from '../tag/tag.sql';
 import { Workspaces } from '../workspace/workspace.sql';
 
@@ -196,39 +195,3 @@ export const EmailTemplateGroupTagsRelations = relations(
 		}),
 	}),
 );
-
-/* Email Deliveries */
-export const EmailDeliveries = pgTable('EmailDeliveries', {
-	...primaryId,
-	...timestamps,
-	workspaceId: dbId('workspaceId')
-		.notNull()
-		.references(() => Workspaces.id),
-	emailTemplateId: dbId('emailTemplateId')
-		.notNull()
-		.references(() => EmailTemplates.id),
-
-	// delivery
-	resendId: text('resendId'),
-	fanId: dbId('fanId')
-		.notNull()
-		.references(() => Fans.id),
-	status: text('status', { enum: ['scheduled', 'sent', 'failed'] }).notNull(),
-	scheduledAt: timestamp('scheduledAt'),
-	sentAt: timestamp('sentAt'),
-});
-
-export const EmailDeliveryRelations = relations(EmailDeliveries, ({ one }) => ({
-	emailTemplate: one(EmailTemplates, {
-		fields: [EmailDeliveries.emailTemplateId],
-		references: [EmailTemplates.id],
-	}),
-	workspace: one(Workspaces, {
-		fields: [EmailDeliveries.workspaceId],
-		references: [Workspaces.id],
-	}),
-	fan: one(Fans, {
-		fields: [EmailDeliveries.fanId],
-		references: [Fans.id],
-	}),
-}));

--- a/packages/lib/trigger/flow.trigger.ts
+++ b/packages/lib/trigger/flow.trigger.ts
@@ -15,10 +15,10 @@ import { dbSchema } from '../server/db';
 import { addToMailchimpAudience } from '../server/mailchimp/mailchimp.endpts.audiences';
 import { getAssetsFromMdx } from '../server/mdx/mdx.fns';
 import { Carts } from '../server/routes/cart/cart.sql';
+import { EmailDeliveries } from '../server/routes/email-delivery/email-delivery.sql';
 import { renderMarkdownToReactEmail } from '../server/routes/email-template/email-template.mdx';
 import {
 	_EmailTemplates_To_EmailTemplateGroups,
-	EmailDeliveries,
 	EmailTemplateGroups,
 	EmailTemplates,
 } from '../server/routes/email-template/email-template.sql';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       superjson:
         specifier: ^2.2.1
         version: 2.2.1
+      svix:
+        specifier: ^1.35.0
+        version: 1.35.0
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.1)
@@ -12614,6 +12617,10 @@ packages:
   /@socket.io/component-emitter@3.1.0:
     resolution: {integrity: sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==}
 
+  /@stablelib/base64@1.0.1:
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+    dev: false
+
   /@stitches/core@1.2.8:
     resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
     dev: false
@@ -17738,6 +17745,10 @@ packages:
       es5-ext: 0.10.62
       es6-symbol: 3.1.3
 
+  /es6-promise@4.2.8:
+    resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
+    dev: false
+
   /es6-symbol@3.1.3:
     resolution: {integrity: sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==}
     dependencies:
@@ -18814,6 +18825,10 @@ packages:
 
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  /fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+    dev: false
 
   /fast-xml-parser@4.2.5:
     resolution: {integrity: sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==}
@@ -26891,6 +26906,27 @@ packages:
       stable: 0.1.8
     dev: true
 
+  /svix-fetch@3.0.0:
+    resolution: {integrity: sha512-rcADxEFhSqHbraZIsjyZNh4TF6V+koloX1OzZ+AQuObX9mZ2LIMhm1buZeuc5BIZPftZpJCMBsSiBaeszo9tRw==}
+    dependencies:
+      node-fetch: 2.7.0(encoding@0.1.13)
+      whatwg-fetch: 3.6.20
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /svix@1.35.0:
+    resolution: {integrity: sha512-YXocwu/isOywSnzcoZsIZddz6g4BVRIZJVSiM+g6EpaFLt8SOt2r+iAuqIy95LTl+3TdxhHB1Ba5vjiOF2m7Ow==}
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      es6-promise: 4.2.8
+      fast-sha256: 1.3.0
+      svix-fetch: 3.0.0
+      url-parse: 1.5.10
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /symbol-observable@1.2.0:
     resolution: {integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==}
     engines: {node: '>=0.10.0'}
@@ -28573,6 +28609,10 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: false
+
+  /whatwg-fetch@3.6.20:
+    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
     dev: false
 
   /whatwg-url@5.0.0:


### PR DESCRIPTION
- add open tracking & click tracking to EmailDomain table && UI
- added resend webhook route
- added RESEND_WEBHOOK_SECRET to app env
- moved EmailDeliveries to it's own server/route folder
- Resend event-fns && schema
- added svix to @barely/app/package.json