### PR TITLE
add asset ids to mdx links, track in cart, & increment purchase value

### DIFF
--- a/apps/cart/src/app/[mode]/[handle]/[key]/_actions/index.ts
+++ b/apps/cart/src/app/[mode]/[handle]/[key]/_actions/index.ts
@@ -1,34 +1,33 @@
 'use server';
 
+import type { EventTrackingProps } from '@barely/lib/server/routes/event/event-report.schema';
 import { cookies } from 'next/headers';
+import { EventTrackingKeys } from '@barely/lib/server/routes/event/event-report.schema';
 
 export async function setCartCookie({
 	handle,
 	key,
 	cartId,
-	fbclid,
-	refererId,
+	tracking,
 }: {
 	handle: string;
 	key: string;
 	cartId: string;
-	fbclid: string | null;
-	refererId?: string;
+	tracking: EventTrackingProps;
 }) {
 	await Promise.resolve();
 	cookies().set(`${handle}.${key}.cartId`, cartId, {
 		maxAge: 60 * 60 * 24 * 7, // 7 days
 	});
 
-	if (fbclid) {
-		cookies().set(`${handle}.${key}.fbclid`, fbclid, {
-			maxAge: 60 * 60 * 24 * 7, // 7 days
-		});
-	}
+	// const { fbclid, refererId, fanId, landingPageId,  } = tracking;
 
-	if (refererId) {
-		cookies().set(`${handle}.${key}.refererId`, refererId, {
-			maxAge: 60 * 60 * 24 * 7, // 7 days
-		});
+	for (const key of EventTrackingKeys) {
+		const value = tracking[key];
+		if (value) {
+			cookies().set(`${handle}.${key}.${key}`, value, {
+				maxAge: 60 * 60 * 24 * 7, // 7 days
+			});
+		}
 	}
 }

--- a/apps/cart/src/app/[mode]/[handle]/[key]/checkout/checkout-form.tsx
+++ b/apps/cart/src/app/[mode]/[handle]/[key]/checkout/checkout-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { CartRouterOutputs } from '@barely/lib/server/routes/cart/cart.api.react';
+import type { EventTrackingProps } from '@barely/lib/server/routes/event/event-report.schema';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { cartApi } from '@barely/lib/server/routes/cart/cart.api.react';
@@ -43,14 +44,15 @@ export function CheckoutForm({
 	mode,
 	initialData,
 	shouldWriteToCookie,
-	fbclid,
+	tracking,
 }: {
 	mode: 'preview' | 'live';
 	initialData:
 		| NonNullable<CartRouterOutputs['create']>
 		| NonNullable<CartRouterOutputs['byIdAndParams']>;
 	shouldWriteToCookie?: boolean;
-	fbclid: string | null;
+	// fbclid: string | null;
+	tracking: EventTrackingProps;
 }) {
 	const router = useRouter();
 	const { cart: initialCart, publicFunnel: initialFunnel } = initialData;
@@ -63,7 +65,7 @@ export function CheckoutForm({
 				handle: initialFunnel.handle,
 				key: initialFunnel.key,
 				cartId: initialCart.id,
-				fbclid,
+				tracking,
 			}).catch(console.error);
 
 			logEvent({
@@ -72,7 +74,7 @@ export function CheckoutForm({
 			});
 		}
 	}, [
-		fbclid,
+		tracking,
 		initialCart.id,
 		initialFunnel.handle,
 		initialFunnel.key,
@@ -229,8 +231,18 @@ export function CheckoutForm({
 		schema: updateCheckoutCartFromCheckoutSchema,
 		values: {
 			...cart,
+
 			handle: publicFunnel.workspace.handle,
 			key: publicFunnel.key,
+
+			// tracking
+			emailBroadcastId: tracking.emailBroadcastId,
+			emailTemplateId: tracking.emailTemplateId,
+			fanId: tracking.fanId,
+			fbclid: tracking.fbclid,
+			flowActionId: tracking.flowActionId,
+			landingPageId: tracking.landingPageId,
+			refererId: tracking.refererId,
 
 			mainProductPayWhatYouWantPrice:
 				cart.mainProductPayWhatYouWantPrice ?

--- a/apps/cart/src/app/[mode]/[handle]/[key]/checkout/page.tsx
+++ b/apps/cart/src/app/[mode]/[handle]/[key]/checkout/page.tsx
@@ -3,6 +3,7 @@ import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { cartApi } from '@barely/lib/server/routes/cart/cart.api.server';
 import { cartPageSearchParams } from '@barely/lib/server/routes/cart/cart.schema';
+import { eventReportSearchParamsSchema } from '@barely/lib/server/routes/event/event-report.schema';
 import { isDevelopment } from '@barely/lib/utils/environment';
 import { getDynamicStyleVariables } from 'node_modules/@barely/tailwind-config/lib/dynamic-tw.runtime';
 
@@ -23,6 +24,7 @@ export default async function CartPage({
 	const { mode, handle, key } = params;
 
 	const cartParams = cartPageSearchParams.safeParse(searchParams);
+	const eventTrackingParams = eventReportSearchParamsSchema.safeParse(searchParams);
 
 	if (!cartParams.success) {
 		console.log('cartParams error', cartParams.error);
@@ -36,8 +38,6 @@ export default async function CartPage({
 	}
 
 	const cartId = cookies().get(`${handle}.${key}.cartId`)?.value;
-	const fbclid =
-		searchParams.fbclid ?? cookies().get(`${handle}.${key}.fbclid`)?.value ?? null;
 
 	//  estimate shipTo from IP
 	const headersList = headers();
@@ -54,7 +54,7 @@ export default async function CartPage({
 				handle,
 				key,
 				shipTo,
-				landingPageId: cartParams.data.landingPageId,
+				tracking: eventTrackingParams.data ?? {},
 			});
 
 	const { defaultHex: colorPrimary } = getDynamicStyleVariables({
@@ -73,7 +73,7 @@ export default async function CartPage({
 					mode={mode}
 					initialData={initialData}
 					shouldWriteToCookie={!cartId}
-					fbclid={fbclid}
+					tracking={eventTrackingParams.data ?? {}}
 				/>
 			</ElementsProvider>
 		</>

--- a/apps/page/src/app/[handle]/[...key]/lp-link-button.tsx
+++ b/apps/page/src/app/[handle]/[...key]/lp-link-button.tsx
@@ -12,17 +12,13 @@ export interface LandingPageLinkButtonProps {
 }
 
 export const LandingPageLinkButton = ({
+	href,
 	landingPageId,
 	assetId,
 	label,
-	...props
+	// ...props
 }: LandingPageLinkButtonProps) => {
 	const { mutate: logEvent } = landingPageApi.log.useMutation();
-
-	const url = new URL(props.href);
-	url.searchParams.set('refererId', landingPageId);
-
-	const href = url.toString();
 
 	return (
 		<LoadingLinkButton

--- a/packages/lib/server/routes/cart-funnel/cart-funnel.sql.ts
+++ b/packages/lib/server/routes/cart-funnel/cart-funnel.sql.ts
@@ -76,6 +76,9 @@ export const CartFunnels = pgTable(
 		count_declineUpsell: integer('count_declineUpsell').default(0),
 		count_purchaseUpsell: integer('count_purchaseUpsell').default(0),
 		count_viewOrderConfirmation: integer('count_viewOrderConfirmation').default(0),
+
+		// stats
+		value: integer('value').default(0),
 	},
 	funnel => ({
 		workspace: index('Funnels_workspaceId_idx').on(funnel.workspaceId),

--- a/packages/lib/server/routes/cart/cart.api.server.ts
+++ b/packages/lib/server/routes/cart/cart.api.server.ts
@@ -2,7 +2,6 @@ import { cache } from 'react';
 import { headers } from 'next/headers';
 
 import { createCallerFactory, createTRPCContext } from '../../api/trpc';
-// import { dbPool } from '../../db';
 import { cartRouter } from './cart.router';
 
 const createContext = cache(() => {

--- a/packages/lib/server/routes/cart/cart.schema.ts
+++ b/packages/lib/server/routes/cart/cart.schema.ts
@@ -3,6 +3,7 @@ import { createInsertSchema } from 'drizzle-zod';
 import { z } from 'zod';
 
 import { formattedUserAgentSchema, nextGeoSchema } from '../../next/next.schema';
+import { eventReportSearchParamsSchema } from '../event/event-report.schema';
 import { Carts } from './cart.sql';
 
 export const insertCartSchema = createInsertSchema(Carts, {
@@ -54,8 +55,8 @@ export const cartPageSearchParams = insertCartSchema
 		bumpProductApparelSize: true,
 	})
 	.partial()
+	.merge(eventReportSearchParamsSchema)
 	.extend({
-		fbclid: z.string().optional(),
 		warmup: z.coerce.boolean().optional(),
 	});
 

--- a/packages/lib/server/routes/cart/cart.sql.ts
+++ b/packages/lib/server/routes/cart/cart.sql.ts
@@ -45,7 +45,12 @@ export const Carts = pgTable(
 		}),
 
 		/* landing page */
+		emailBroadcastId: dbId('emailBroadcastId'),
+		emailTemplateId: dbId('emailTemplateId'),
 		landingPageId: dbId('landingPageId'),
+		refererId: dbId('refererId'),
+		fbclid: varchar('fbclid', { length: 255 }),
+		flowActionId: dbId('flowActionId'),
 
 		/* 
             🛒 cart checkout (main + bump) 

--- a/packages/lib/server/routes/email-broadcast/email-broadcast.sql.ts
+++ b/packages/lib/server/routes/email-broadcast/email-broadcast.sql.ts
@@ -1,5 +1,5 @@
 import { relations } from 'drizzle-orm';
-import { pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 
 import { dbId, primaryId, timestamps } from '../../../utils/sql';
 import { EmailTemplates } from '../email-template/email-template.sql';
@@ -31,6 +31,8 @@ export const EmailBroadcasts = pgTable('EmailBroadcasts', {
 
 	error: text('error'),
 	triggerRunId: text('triggerRunId'),
+
+	value: integer('value').default(0),
 });
 
 export const EmailBroadcastRelations = relations(EmailBroadcasts, ({ one }) => ({

--- a/packages/lib/server/routes/email-template/email-template.mdx.tsx
+++ b/packages/lib/server/routes/email-template/email-template.mdx.tsx
@@ -5,11 +5,9 @@ import { EmailButton, EmailImage, EmailLink } from '@barely/email/src/primitives
 import { Heading, Text } from '@react-email/components';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 
+import type { MdxAssets } from '../../../utils/mdx';
 import type { MdxImageSize } from '../../mdx/mdx.constants';
-import type { CartFunnel } from '../cart-funnel/cart-funnel.schema';
-import type { LandingPage } from '../landing-page/landing-page.schema';
-import type { Link } from '../link/link.schema';
-import type { PressKit } from '../press-kit/press-kit.schema';
+import type { EventTrackingProps } from '../event/event-report.schema';
 import type { EmailTemplateVariableName } from './email-template.constants';
 import { env } from '../../../env';
 import { getAssetHref, getLinkHref } from '../../../utils/mdx';
@@ -19,25 +17,15 @@ export async function renderMarkdownToReactEmail({
 	subject,
 	body,
 	variables,
-	fanId,
-	emailTemplateId,
-	cartFunnels,
-	landingPages,
-	links,
-	pressKits,
+	tracking,
+	assets,
 	listUnsubscribeUrl,
 }: {
 	subject: string;
 	body: string;
 	variables: Record<EmailTemplateVariableName, string>;
-	// tracking
-	emailTemplateId: string;
-	fanId: string;
-	// assets
-	cartFunnels: CartFunnel[];
-	landingPages: LandingPage[];
-	links: Link[];
-	pressKits: PressKit[];
+	tracking: EventTrackingProps;
+	assets: MdxAssets;
 	listUnsubscribeUrl?: string;
 }) {
 	// Replace variables with values or empty string if not found
@@ -58,16 +46,12 @@ export async function renderMarkdownToReactEmail({
 		h5: ({ children }: { children?: ReactNode }) => <Heading as='h5'>{children}</Heading>,
 		h6: ({ children }: { children?: ReactNode }) => <Heading as='h6'>{children}</Heading>,
 
-		...mdxEmailLink({ fanId, emailTemplateId }),
+		...mdxEmailLink({ tracking }),
 		...mdxEmailImageFile(),
-		...mdxLinkButton({ fanId, emailTemplateId }),
+		...mdxLinkButton({ tracking }),
 		...mdxEmailAssetButton({
-			fanId,
-			emailTemplateId,
-			cartFunnels,
-			landingPages,
-			links,
-			pressKits,
+			tracking,
+			assets,
 		}),
 	};
 
@@ -98,16 +82,9 @@ export async function renderMarkdownToReactEmail({
 	};
 }
 
-function mdxEmailLink({
-	fanId,
-	emailTemplateId,
-}: {
-	fanId: string;
-	emailTemplateId: string;
-}) {
+function mdxEmailLink({ tracking }: { tracking: EventTrackingProps }) {
 	const MdxEmailLink = ({ href, children }: { href?: string; children?: ReactNode }) => {
-		const hrefWithQueryParams =
-			href ? getLinkHref({ href, fanId, refererId: emailTemplateId }) : '';
+		const hrefWithQueryParams = href ? getLinkHref({ href, tracking }) : '';
 		return <EmailLink href={hrefWithQueryParams}>{children}</EmailLink>;
 	};
 
@@ -153,15 +130,9 @@ function mdxEmailImageFile() {
 	};
 }
 
-function mdxLinkButton({
-	fanId,
-	emailTemplateId,
-}: {
-	fanId: string;
-	emailTemplateId: string;
-}) {
+function mdxLinkButton({ tracking }: { tracking: EventTrackingProps }) {
 	const LinkButton = ({ href, label }: { href: string; label: string }) => {
-		const hrefWithQueryParams = getLinkHref({ href, fanId, refererId: emailTemplateId });
+		const hrefWithQueryParams = getLinkHref({ href, tracking });
 
 		return <EmailButton href={hrefWithQueryParams}>{label}</EmailButton>;
 	};
@@ -172,29 +143,17 @@ function mdxLinkButton({
 }
 
 function mdxEmailAssetButton({
-	emailTemplateId,
-	cartFunnels,
-	landingPages,
-	links,
-	pressKits,
-	fanId,
+	tracking,
+	assets,
 }: {
-	emailTemplateId: string;
-	cartFunnels: CartFunnel[];
-	landingPages: LandingPage[];
-	links: Link[];
-	pressKits: PressKit[];
-	fanId: string;
+	tracking: EventTrackingProps;
+	assets: MdxAssets;
 }) {
 	const AssetButton = ({ assetId, label }: { assetId: string; label: string }) => {
 		const href = getAssetHref({
 			assetId,
-			cartFunnels,
-			landingPages,
-			links,
-			pressKits,
-			refererId: emailTemplateId,
-			fanId,
+			assets,
+			tracking,
 		});
 
 		return <EmailButton href={href}>{label}</EmailButton>;

--- a/packages/lib/server/routes/email-template/email-template.router.ts
+++ b/packages/lib/server/routes/email-template/email-template.router.ts
@@ -178,13 +178,16 @@ export const emailTemplateRouter = createTRPCRouter({
 				subject: input.subject,
 				body: input.body,
 				variables,
-				cartFunnels,
-				landingPages,
-				links,
-				pressKits,
-				// tracking
-				emailTemplateId: '',
-				fanId: '',
+				tracking: {
+					emailTemplateId: '',
+					fanId: '',
+				},
+				assets: {
+					cartFunnels,
+					landingPages,
+					links,
+					pressKits,
+				},
 				listUnsubscribeUrl: type === 'marketing' ? 'email_delivery_test' : undefined,
 			});
 

--- a/packages/lib/server/routes/email-template/email-template.sql.ts
+++ b/packages/lib/server/routes/email-template/email-template.sql.ts
@@ -43,6 +43,8 @@ export const EmailTemplates = pgTable('EmailTemplates', {
 	replyTo: text('replyTo'),
 	subject: text('subject').notNull(),
 	body: text('body').notNull(),
+
+	value: integer('value').default(0),
 });
 
 export const EmailTemplateRelations = relations(EmailTemplates, ({ one, many }) => ({

--- a/packages/lib/server/routes/event/event-report.schema.ts
+++ b/packages/lib/server/routes/event/event-report.schema.ts
@@ -21,8 +21,26 @@ export type EventReport = InferSelectModel<typeof EventReports>;
 export type InsertEventReport = InferInsertModel<typeof EventReports>;
 export type CreateEventReport = z.infer<typeof createEventReportSchema>;
 
+export const EventTrackingKeys = [
+	'emailBroadcastId',
+	'emailTemplateId',
+	'fanId',
+	'fbclid',
+	'flowActionId',
+	'landingPageId',
+	'refererId',
+] as const;
+
+export type EventTrackingProps = Partial<
+	Record<(typeof EventTrackingKeys)[number], string>
+>;
+
 export const eventReportSearchParamsSchema = z.object({
+	emailBroadcastId: z.string().optional(),
+	emailTemplateId: z.string().optional(),
 	fanId: z.string().optional(),
 	fbclid: z.string().optional(),
+	flowActionId: z.string().optional(),
+	landingPageId: z.string().optional(),
 	refererId: z.string().optional(),
 });

--- a/packages/lib/server/routes/flow/flow.sql.ts
+++ b/packages/lib/server/routes/flow/flow.sql.ts
@@ -132,6 +132,9 @@ export const Flow_Actions = pgTable(
 		cartFunnelId: dbId('cartFunnelId').references(() => CartFunnels.id),
 		totalOrderAmount: integer('totalOrderAmount'), // in cents
 		mailchimpAudienceId: text('mailchimpAudienceId'),
+
+		// stats
+		value: integer('value').default(0),
 	},
 	table => ({
 		primaryKey: primaryKey({ columns: [table.flowId, table.id] }),

--- a/packages/lib/server/routes/landing-page/landing-page.sql.ts
+++ b/packages/lib/server/routes/landing-page/landing-page.sql.ts
@@ -49,6 +49,7 @@ export const LandingPages = pgTable(
 		// stats
 		views: integer('views').default(0),
 		clicks: integer('clicks').default(0),
+		value: integer('value').default(0),
 	},
 	lp => ({
 		workspace: index('lp_workspaceId_idx').on(lp.workspaceId),

--- a/packages/lib/trigger/email-broadcast.trigger.ts
+++ b/packages/lib/trigger/email-broadcast.trigger.ts
@@ -187,9 +187,11 @@ export const handleEmailBroadcast = task({
 });
 
 async function getEmailDataForBatch({
+	emailBroadcast,
 	emailTemplate,
 	fan,
 }: {
+	emailBroadcast: EmailBroadcast;
 	emailTemplate: EmailTemplateWithFrom;
 	fan: FanForEmail;
 }) {
@@ -211,11 +213,13 @@ async function getEmailDataForBatch({
 			firstName,
 			lastName,
 		},
-		// tracking
-		emailTemplateId: emailTemplate.id,
-		fanId: fan.id,
+		tracking: {
+			emailTemplateId: emailTemplate.id,
+			fanId: fan.id,
+			emailBroadcastId: emailBroadcast.id,
+		},
 		// assets
-		...assets,
+		assets,
 	});
 
 	const toEmail =
@@ -252,6 +256,7 @@ async function handleSendEmailBatch({
 	const emails = await Promise.all(
 		fans.map(fan =>
 			getEmailDataForBatch({
+				emailBroadcast,
 				emailTemplate,
 				fan,
 			}),

--- a/packages/lib/trigger/flow.trigger.ts
+++ b/packages/lib/trigger/flow.trigger.ts
@@ -748,15 +748,19 @@ async function handleSendEmailFromTemplateToFan({
 			firstName,
 			lastName,
 		},
-		// tracking
-		emailTemplateId: emailTemplate.id,
-		fanId: fan.id,
-		// asets
-		cartFunnels,
-		landingPages,
-		links,
-		pressKits,
-		// unsubscribe
+
+		tracking: {
+			emailTemplateId: emailTemplate.id,
+			fanId: fan.id,
+			flowActionId: action.id,
+		},
+
+		assets: {
+			cartFunnels,
+			landingPages,
+			links,
+			pressKits,
+		},
 		listUnsubscribeUrl:
 			emailTemplate.type === 'marketing' ? listUnsubscribeUrl : undefined,
 	});

--- a/packages/lib/utils/mdx.ts
+++ b/packages/lib/utils/mdx.ts
@@ -1,32 +1,30 @@
 import type { CartFunnel } from '../server/routes/cart-funnel/cart-funnel.schema';
+import type { EventTrackingProps } from '../server/routes/event/event-report.schema';
 import type { LandingPage } from '../server/routes/landing-page/landing-page.schema';
 import type { Link } from '../server/routes/link/link.schema';
 import type { PressKit } from '../server/routes/press-kit/press-kit.schema';
+import { EventTrackingKeys } from '../server/routes/event/event-report.schema';
 import { getAbsoluteUrl } from './url';
 
-export function getAssetHref({
-	assetId,
-	// assets
-	cartFunnels,
-	landingPages,
-	links,
-	pressKits,
-	// tracking
-	fanId,
-	refererId,
-	fbclid,
-}: {
-	assetId: string;
-	// assets
+export interface MdxAssets {
 	cartFunnels: CartFunnel[];
 	landingPages: LandingPage[];
 	links: Link[];
 	pressKits: PressKit[];
-	fanId?: string;
-	refererId: string;
-	fbclid?: string;
+}
+
+export function getAssetHref({
+	assetId,
+	assets,
+	tracking,
+}: {
+	assetId: string;
+	assets: MdxAssets;
+	tracking: EventTrackingProps;
 }): string {
 	let href = '#';
+
+	const { cartFunnels, landingPages, links, pressKits } = assets;
 
 	const funnel = cartFunnels.find(funnel => funnel.id === assetId);
 	if (funnel) {
@@ -50,39 +48,24 @@ export function getAssetHref({
 		});
 	}
 
-	const url = new URL(href);
-	if (refererId) {
-		url.searchParams.set('refererId', refererId);
-	}
-	if (fanId) {
-		url.searchParams.set('fanId', fanId);
-	}
-	if (fbclid) {
-		url.searchParams.set('fbclid', fbclid);
-	}
+	const url = getLinkHref({ href, tracking });
 	return url.toString();
 }
 
 export function getLinkHref({
 	href,
-	refererId,
-	fanId,
-	fbclid,
+	tracking,
 }: {
 	href: string;
-	refererId: string;
-	fanId?: string;
-	fbclid?: string;
+	tracking: EventTrackingProps;
 }): string {
 	const url = new URL(href);
-	if (refererId) {
-		url.searchParams.set('refererId', refererId);
-	}
-	if (fanId) {
-		url.searchParams.set('fanId', fanId);
-	}
-	if (fbclid) {
-		url.searchParams.set('fbclid', fbclid);
+
+	for (const key of EventTrackingKeys) {
+		const value = tracking[key];
+		if (value) {
+			url.searchParams.set(key, value);
+		}
 	}
 	return url.toString();
 }


### PR DESCRIPTION
- standardized EventTrackingProps
- extended eventReportSearchParamsSchema to include new assets (same as EventTrackingKeys
- pass 'tracking' prop between functions that do tracking (instead of writing out each assetId)
- added value prop to appropriate asset tables (EmailBroadcasts, EmailTemplates, CartFunnels, FlowAction, LandingPage)
- increment value on Cart Checkout (Stripe webhook) and Cart Upsell Purchase (cart.router)