### PR TITLE
added additional params to Meta CAPI reporting

### DIFF
--- a/packages/lib/server/meta/meta.endpts.event.ts
+++ b/packages/lib/server/meta/meta.endpts.event.ts
@@ -96,10 +96,15 @@ export interface MetaEventProps {
 
 	// event data (covers all events)
 	sourceUrl: string;
+	email?: string;
+	phone?: string;
+	firstName?: string;
+	lastName?: string;
 	ip?: string;
 	ua?: string;
 	time?: number;
 	geo?: NextGeo;
+
 	eventId?: string;
 	testEventCode?: string;
 
@@ -111,7 +116,7 @@ export interface MetaEventProps {
 }
 
 export async function reportEventsToMeta(props: MetaEventProps) {
-	const { ip, geo, ua, time } = props;
+	const { ip, geo, ua, time, email, phone, firstName, lastName } = props;
 	const { pixelId, accessToken, sourceUrl, events } = props;
 
 	const urlObject = new URL(sourceUrl);
@@ -123,8 +128,13 @@ export async function reportEventsToMeta(props: MetaEventProps) {
 	const userData = metaUserDataSchema.parse({
 		ip,
 		ua,
+		email,
+		phone,
+		firstName,
+		lastName,
 		city: geo?.city,
 		state: geo?.region,
+		zipCode: geo?.zip,
 		country: geo?.country,
 		fbc: fbclid ? `fb.1.${unixTimeSinceEpoch_ms}.${fbclid}` : undefined,
 	});
@@ -146,14 +156,6 @@ export async function reportEventsToMeta(props: MetaEventProps) {
 		}
 	});
 
-	// const serverEventData = metaServerEventSchema.parse({
-	// 	eventName,
-	// 	eventTime: unixTimeSinceEpoch_s,
-	// 	actionSource: 'website',
-	// 	sourceUrl,
-	// 	customData: props.customData,
-	// });
-
 	const testEventCode = isDevelopment() ? env.META_TEST_EVENT_CODE : undefined;
 
 	if (testEventCode)
@@ -170,8 +172,6 @@ export async function reportEventsToMeta(props: MetaEventProps) {
 				body: {
 					access_token: accessToken,
 					data,
-					// data: [{ user_data: userData, ...serverEventData }],
-
 					// test event code
 					...(testEventCode !== undefined && {
 						test_event_code: testEventCode,

--- a/packages/lib/server/next/next.schema.ts
+++ b/packages/lib/server/next/next.schema.ts
@@ -91,6 +91,7 @@ export const nextGeoSchema = z.object({
 	latitude: z.string().nullish().default('Unknown'),
 	longitude: z.string().nullish().default('Unknown'),
 	region: z.string().nullish().default('Unknown'),
+	zip: z.string().nullish().default('Unknown'),
 });
 
 // export const formattedNextGeoSchema = z.object({

--- a/packages/lib/server/routes/link/link.constants.ts
+++ b/packages/lib/server/routes/link/link.constants.ts
@@ -19,6 +19,7 @@ export const DUMMY_GEO_DATA: NextGeo[] = [
 		country: 'GB',
 		latitude: '51.5074',
 		longitude: '-0.1278',
+		zip: 'EC1A 1BB',
 	},
 	{
 		city: 'Manchester',
@@ -26,6 +27,7 @@ export const DUMMY_GEO_DATA: NextGeo[] = [
 		country: 'GB',
 		latitude: '53.4808',
 		longitude: '-2.2426',
+		zip: 'M1 1AA',
 	},
 	{
 		city: 'Toronto',
@@ -33,6 +35,7 @@ export const DUMMY_GEO_DATA: NextGeo[] = [
 		country: 'CA',
 		latitude: '43.6532',
 		longitude: '-79.3832',
+		zip: 'M1 1AA',
 	},
 	{
 		city: 'Sydney',
@@ -40,6 +43,7 @@ export const DUMMY_GEO_DATA: NextGeo[] = [
 		country: 'AU',
 		latitude: '-33.8688',
 		longitude: '151.2093',
+		zip: '2000',
 	},
 	{
 		city: 'Auckland',
@@ -47,6 +51,7 @@ export const DUMMY_GEO_DATA: NextGeo[] = [
 		country: 'NZ',
 		latitude: '-36.8485',
 		longitude: '174.7633',
+		zip: '1010',
 	},
 	{
 		city: 'New York',
@@ -54,6 +59,7 @@ export const DUMMY_GEO_DATA: NextGeo[] = [
 		country: 'US',
 		latitude: '40.7128',
 		longitude: '74.0060',
+		zip: '10001',
 	},
 	{
 		city: 'Los Angeles',
@@ -61,6 +67,7 @@ export const DUMMY_GEO_DATA: NextGeo[] = [
 		country: 'US',
 		latitude: '34.0522',
 		longitude: '118.2437',
+		zip: '90001',
 	},
 	{
 		city: 'Chicago',
@@ -68,6 +75,7 @@ export const DUMMY_GEO_DATA: NextGeo[] = [
 		country: 'US',
 		latitude: '41.8781',
 		longitude: '87.6298',
+		zip: '60601',
 	},
 	{
 		city: 'Houston',
@@ -75,6 +83,7 @@ export const DUMMY_GEO_DATA: NextGeo[] = [
 		country: 'US',
 		latitude: '29.7604',
 		longitude: '95.3698',
+		zip: '77001',
 	},
 	{
 		city: 'Phoenix',
@@ -82,6 +91,7 @@ export const DUMMY_GEO_DATA: NextGeo[] = [
 		country: 'US',
 		latitude: '33.4484',
 		longitude: '112.0740',
+		zip: '85001',
 	},
 ];
 

--- a/packages/lib/trigger/email-broadcast.trigger.ts
+++ b/packages/lib/trigger/email-broadcast.trigger.ts
@@ -234,7 +234,7 @@ async function getEmailDataForBatch({
 		emailDeliveryId,
 		fanId: fan.id,
 		to: toEmail,
-		bcc: 'adam+broadcast-monitoring@barely.io', // fixme: remove once we're happy with this
+		// bcc: 'adam+broadcast-monitoring@barely.io',
 		from: getEmailAddressFromEmailAddress(emailTemplate.from),
 		fromFriendlyName: emailTemplate.from.defaultFriendlyName ?? undefined,
 		replyTo: emailTemplate.from.replyTo ?? undefined,

--- a/packages/lib/trigger/flow.trigger.ts
+++ b/packages/lib/trigger/flow.trigger.ts
@@ -769,7 +769,7 @@ async function handleSendEmailFromTemplateToFan({
 
 	const res = await sendEmail({
 		to: fan.email,
-		bcc: 'adam+flow-monitoring@barely.io',
+		// bcc: 'adam+flow-monitoring@barely.io',
 		from: getEmailAddressFromEmailAddress(emailTemplate.from),
 		fromFriendlyName: emailTemplate.from.defaultFriendlyName ?? undefined,
 		replyTo: emailTemplate.from.replyTo ?? undefined,

--- a/packages/lib/utils/name.ts
+++ b/packages/lib/utils/name.ts
@@ -1,3 +1,14 @@
+export function getFirstAndLastName(p: {
+	fullName?: string | null;
+	firstName?: string | null;
+	lastName?: string | null;
+}) {
+	const firstName = p.firstName ?? parseFullName(p.fullName ?? '').firstName;
+	const lastName = p.lastName ?? parseFullName(p.fullName ?? '').lastName;
+
+	return { firstName, lastName };
+}
+
 export function parseFullName(fullName: string) {
 	const [firstName, ...rest] = fullName.split(' ');
 	const lastName = rest.join(' ');
@@ -22,6 +33,19 @@ export function getFullNameFromFirstAndLast(
 	}
 
 	return '';
+}
+
+export function getFullName({
+	firstName,
+	lastName,
+	fullName,
+}: {
+	firstName?: string | null;
+	lastName?: string | null;
+	fullName?: string | null;
+}) {
+	if (fullName && fullName.length > 0) return fullName;
+	return getFullNameFromFirstAndLast(firstName, lastName);
 }
 
 export function initials(string: string) {


### PR DESCRIPTION
- for meta event reporting, include hashed email (if opted in), sms (if opted in), firstName, lastName, zip
- use updatedCart for reporting Stripe Connect event
- removed bcc monitoring from broadcast & flow emails
- added getFirstAndLastName util that takes fullName, firstName, and lastName as arguments.
- added getFullName util that takes fullName, firstName, and lastName as arguments. defaults to fullName if provided.