### PR TITLE
optimistically set current workspace w/ switcher

### DIFF
--- a/apps/app/src/app/[handle]/_components/dash-sidebar-nav.tsx
+++ b/apps/app/src/app/[handle]/_components/dash-sidebar-nav.tsx
@@ -11,7 +11,7 @@ import { useAtomValue } from 'jotai';
 
 import { navHistoryAtom } from '@barely/atoms/navigation-history.atom';
 
-import { usePathnameMatchesCurrentPath } from '@barely/hooks/use-pathname-matches-current-path';
+import { usePathnameEndsWith } from '@barely/hooks/use-pathname-matches-current-path';
 import { useWorkspaces } from '@barely/hooks/use-workspaces';
 
 import { Icon } from '@barely/ui/elements/icon';
@@ -45,10 +45,11 @@ interface SidebarNavGroup {
 
 type SidebarNavItem = SidebarNavLink | SidebarNavGroup;
 
-export function SidebarNav(props: { workspace: Workspace }) {
-	const handle = props.workspace.handle;
+export function SidebarNav() {
+	// const handle = props.workspace.handle;
 	const pathname = usePathname();
 	const workspace = useWorkspace();
+	const handle = workspace.handle;
 	const workspaces = useWorkspaces();
 
 	const allHandles = workspaces.map(workspace => workspace.handle);
@@ -194,7 +195,7 @@ export function SidebarNav(props: { workspace: Workspace }) {
 
 							return (
 								<Fragment key={index}>
-									<NavItem item={item} />
+									<NavItem item={item} handle={handle} />
 								</Fragment>
 							);
 						})}
@@ -217,11 +218,13 @@ export function SidebarNav(props: { workspace: Workspace }) {
 	);
 }
 
-function NavLink(props: { item: SidebarNavLink }) {
+function NavLink(props: { item: SidebarNavLink; handle: string }) {
 	const NavIcon = props.item.icon ? Icon[props.item.icon] : null;
 
-	const isCurrent = usePathnameMatchesCurrentPath(props.item.href ?? '');
-
+	// const isCurrent = usePathnameMatchesCurrentPath(props.item.href ?? '');
+	const isCurrent = usePathnameEndsWith(
+		props.item.href?.replace(`/${props.handle}`, '') ?? '',
+	);
 	return (
 		<Link
 			href={props.item.href ?? '#'}
@@ -237,7 +240,7 @@ function NavLink(props: { item: SidebarNavLink }) {
 	);
 }
 
-function NavGroup(props: { item: SidebarNavGroup }) {
+function NavGroup(props: { item: SidebarNavGroup; handle: string }) {
 	const NavIcon = props.item.icon ? Icon[props.item.icon] : null;
 
 	const isCurrentGroup = usePathnameMatchesCurrentGroup(
@@ -282,7 +285,7 @@ function NavGroup(props: { item: SidebarNavGroup }) {
 					)}
 				>
 					{props.item.links.map((item, index) => (
-						<NavLink key={index} item={item} />
+						<NavLink key={index} item={item} handle={props.handle} />
 					))}
 				</div>
 			)}
@@ -290,8 +293,8 @@ function NavGroup(props: { item: SidebarNavGroup }) {
 	);
 }
 
-function NavItem(props: { item: SidebarNavItem }) {
+function NavItem(props: { item: SidebarNavItem; handle: string }) {
 	return 'links' in props.item ?
-			<NavGroup item={props.item} />
-		:	<NavLink item={props.item} />;
+			<NavGroup item={props.item} handle={props.handle} />
+		:	<NavLink item={props.item} handle={props.handle} />;
 }

--- a/apps/app/src/app/[handle]/_components/providers.tsx
+++ b/apps/app/src/app/[handle]/_components/providers.tsx
@@ -41,8 +41,6 @@ function WorkspaceUpdateNavHistory({ children }: { children: ReactNode }) {
 export function WorkspaceProviders(
 	props: UserContextProviderProps & WorkspaceContextProviderProps,
 ) {
-	// useUpdateNavHistory();
-
 	return (
 		<UserContextProvider user={props.user}>
 			<WorkspaceContextProvider workspace={props.workspace}>

--- a/apps/app/src/app/[handle]/_types/all-items-context.tsx
+++ b/apps/app/src/app/[handle]/_types/all-items-context.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import type { FetchNextPageOptions } from '@tanstack/react-query';
+import type { Selection } from 'react-aria-components';
+
+export interface InfiniteItemsContext<T, P> {
+	items: T[];
+	selection: Selection;
+	lastSelectedItemId: string | undefined;
+	lastSelectedItem: T | undefined;
+	setSelection: (selection: Selection) => void;
+
+	// ui
+	gridListRef: React.RefObject<HTMLDivElement>;
+	focusGridList: () => void;
+
+	// modals
+	showCreateModal: boolean;
+	setShowCreateModal: (show: boolean) => void;
+	showUpdateModal: boolean;
+	setShowUpdateModal: (show: boolean) => void;
+	showDeleteModal: boolean;
+	setShowDeleteModal: (show: boolean) => void;
+	showArchiveModal: boolean;
+	setShowArchiveModal: (show: boolean) => void;
+
+	// common filters
+	filters: P;
+	pendingFiltersTransition: boolean;
+	setSearch: (search: string) => void;
+	toggleArchived: () => void;
+	clearAllFilters: () => void;
+
+	// query
+	hasNextPage: boolean;
+	fetchNextPage: (options?: FetchNextPageOptions) => void | Promise<void>;
+	isFetchingNextPage: boolean;
+	isRefetching: boolean;
+	isFetching: boolean;
+	isPending: boolean;
+}
+
+// export function useInfiniteItems<I, P>({
+// 	children,
+//     initialFirstPage,
+//     filterParamsSchema
+// }: {
+// 	children: React.ReactNode;
+//     initialFirstPage: Promise<I>;
+//     filterParamsSchema: z.ZodType<P>;
+// }) {
+
+//     const [showCreateModal, setShowCreateModal] = useState(false);
+//     const [showUpdateModal, setShowUpdateModal] = useState(false);
+//     const [showDeleteModal, setShowDeleteModal] = useState(false);
+//     const [showArchiveModal, setShowArchiveModal] = useState(false);
+
+//     const {handle} = useWorkspace();
+
+//     const {data, setQuery, removeByKey, removeAllQueryParams, pending} = useTypedOptimisticQuery(filterParamsSchema);
+
+//     const {selectedItemIds, ...filters} = data;
+
+//     const selection: Selection = !selectedItemIds ? new Set() : selectedItemIds === 'all' ? 'all' : new Set(selectedItemIds);
+
+//     const initialData = use(initialFirstPage);
+
+//     const {
+//         data: infiniteItems,
+//         hasNextPage,
+//         fetchNextPage,
+//         isFetchingNextPage,
+//         isRefetching,
+//         isFetching,
+//         isPending
+//     } = api.emailTemplate.byWorkspace.useInfiniteQuery(
+//         {handle, ...filters},
+//         {
+//             initialPageParam: initialData
+//         }
+//     )
+
+// 	return {children};
+// }

--- a/apps/app/src/app/[handle]/carts/_components/all-cartFunnels.tsx
+++ b/apps/app/src/app/[handle]/carts/_components/all-cartFunnels.tsx
@@ -3,6 +3,7 @@
 import type { CartFunnel } from '@barely/lib/server/routes/cart-funnel/cart-funnel.schema';
 import { formatCentsToDollars } from '@barely/lib/utils/currency';
 
+import { GridListSkeleton } from '@barely/ui/components/grid-list-skeleton';
 import { NoResultsPlaceholder } from '@barely/ui/components/no-results-placeholder';
 import { GridList, GridListCard } from '@barely/ui/elements/grid-list';
 
@@ -16,6 +17,8 @@ export function AllCartFunnels() {
 		setCartFunnelSelection,
 		gridListRef,
 		setShowUpdateCartFunnelModal,
+
+		isFetching,
 	} = useCartFunnelContext();
 
 	return (
@@ -36,18 +39,19 @@ export function AllCartFunnels() {
 					setShowUpdateCartFunnelModal(true);
 				}}
 				// empty
-				renderEmptyState={() => (
-					<NoResultsPlaceholder
-						icon='cart'
-						title='No carts found.'
-						subtitle='Create a cart to get started.'
-						button={<CreateCartFunnelButton />}
-					/>
-				)}
+				renderEmptyState={() =>
+					isFetching ?
+						<GridListSkeleton />
+					:	<NoResultsPlaceholder
+							icon='cart'
+							title='No carts found.'
+							subtitle='Create a cart to get started.'
+							button={<CreateCartFunnelButton />}
+						/>
+				}
 			>
 				{funnel => <CartFunnelCard cartFunnel={funnel} />}
 			</GridList>
-			{/* <pre>{JSON.stringify(mailchimpAudiences, null, 2)}</pre> */}
 		</>
 	);
 }

--- a/apps/app/src/app/[handle]/carts/_components/cartFunnel-context.tsx
+++ b/apps/app/src/app/[handle]/carts/_components/cartFunnel-context.tsx
@@ -34,6 +34,10 @@ interface CartFunnelContext {
 	setSearch: (search: string) => void;
 	toggleArchived: () => void;
 	clearAllFilters: () => void;
+
+	isPending: boolean;
+	isFetching: boolean;
+	isRefetching: boolean;
 }
 
 const CartFunnelContext = createContext<CartFunnelContext | undefined>(undefined);
@@ -64,7 +68,12 @@ export function CartFunnelContextProvider({
 
 	const initialData = use(initialInfiniteCartFunnels);
 
-	const { data: infiniteFunnels } = api.cartFunnel.byWorkspace.useInfiniteQuery(
+	const {
+		data: infiniteFunnels,
+		isRefetching,
+		isFetching,
+		isPending,
+	} = api.cartFunnel.byWorkspace.useInfiniteQuery(
 		{
 			handle,
 			...filters,
@@ -148,6 +157,9 @@ export function CartFunnelContextProvider({
 		setSearch,
 		toggleArchived,
 		clearAllFilters,
+		isRefetching,
+		isFetching,
+		isPending,
 	} satisfies CartFunnelContext;
 
 	return (

--- a/apps/app/src/app/[handle]/email-broadcasts/_components/all-email-broadcasts.tsx
+++ b/apps/app/src/app/[handle]/email-broadcasts/_components/all-email-broadcasts.tsx
@@ -4,6 +4,7 @@ import type { AppRouterOutputs } from '@barely/lib/server/api/router';
 import { formatCentsToDollars } from '@barely/lib/utils/currency';
 import { formatDate } from '@barely/lib/utils/format-date';
 
+import { GridListSkeleton } from '@barely/ui/components/grid-list-skeleton';
 // import { useWorkspace } from '@barely/lib/hooks/use-workspace';
 // import { api } from '@barely/lib/server/api/react';
 
@@ -18,12 +19,13 @@ import { useEmailBroadcastsContext } from './email-broadcasts-context';
 
 export function AllEmailBroadcasts() {
 	const {
-		emailBroadcasts,
-		emailBroadcastSelection,
-		lastSelectedEmailBroadcastId,
-		setEmailBroadcastSelection,
+		items,
+		selection,
+		lastSelectedItemId,
+		setSelection,
 		gridListRef,
-		setShowUpdateEmailBroadcastModal,
+		setShowUpdateModal,
+		isFetching,
 	} = useEmailBroadcastsContext();
 
 	return (
@@ -35,24 +37,26 @@ export function AllEmailBroadcasts() {
 				selectionMode='multiple'
 				selectionBehavior='replace'
 				onAction={() => {
-					if (!lastSelectedEmailBroadcastId) return;
-					setShowUpdateEmailBroadcastModal(true);
+					if (!lastSelectedItemId) return;
+					setShowUpdateModal(true);
 				}}
-				items={emailBroadcasts}
-				selectedKeys={emailBroadcastSelection}
-				setSelectedKeys={setEmailBroadcastSelection}
-				renderEmptyState={() => (
-					<NoResultsPlaceholder
-						icon='broadcast'
-						title='No Email Broadcasts'
-						subtitle='Create a new email broadcast to get started.'
-						button={<CreateEmailBroadcastButton />}
-					/>
-				)}
+				items={items}
+				selectedKeys={selection}
+				setSelectedKeys={setSelection}
+				renderEmptyState={() =>
+					isFetching ?
+						<GridListSkeleton />
+					:	<NoResultsPlaceholder
+							icon='broadcast'
+							title='No Email Broadcasts'
+							subtitle='Create a new email broadcast to get started.'
+							button={<CreateEmailBroadcastButton />}
+						/>
+				}
 			>
 				{emailBroadcast => <EmailBroadcastCard emailBroadcast={emailBroadcast} />}
 			</GridList>
-			<LoadMoreButton />
+			{!!items.length && <LoadMoreButton />}
 		</div>
 	);
 }
@@ -95,14 +99,14 @@ function EmailBroadcastCard({
 		deliveries,
 	} = emailBroadcast;
 
-	const { setShowUpdateEmailBroadcastModal } = useEmailBroadcastsContext();
+	const { setShowUpdateModal } = useEmailBroadcastsContext();
 
 	return (
 		<GridListCard
 			id={id}
 			key={id}
 			textValue={emailTemplate.name}
-			setShowUpdateModal={setShowUpdateEmailBroadcastModal}
+			setShowUpdateModal={setShowUpdateModal}
 			title={emailTemplate.name}
 			subtitle={emailTemplate.name}
 			description={

--- a/apps/app/src/app/[handle]/email-broadcasts/_components/create-email-broadcast-button.tsx
+++ b/apps/app/src/app/[handle]/email-broadcasts/_components/create-email-broadcast-button.tsx
@@ -5,12 +5,12 @@ import { Button } from '@barely/ui/elements/button';
 import { useEmailBroadcastsContext } from './email-broadcasts-context';
 
 export function CreateEmailBroadcastButton() {
-	const { setShowCreateEmailBroadcastModal } = useEmailBroadcastsContext();
+	const { setShowCreateModal } = useEmailBroadcastsContext();
 
 	return (
 		<Button
 			onClick={() => {
-				setShowCreateEmailBroadcastModal(true);
+				setShowCreateModal(true);
 			}}
 			className='space-x-3'
 		>

--- a/apps/app/src/app/[handle]/email-broadcasts/_components/create-or-update-email-broadcast-modal.tsx
+++ b/apps/app/src/app/[handle]/email-broadcasts/_components/create-or-update-email-broadcast-modal.tsx
@@ -27,11 +27,11 @@ export function CreateOrUpdateEmailBroadcastModal({
 	const apiUtils = api.useUtils();
 
 	const {
-		lastSelectedEmailBroadcast: selectedEmailBroadcast,
-		showCreateEmailBroadcastModal,
-		showUpdateEmailBroadcastModal,
-		setShowCreateEmailBroadcastModal,
-		setShowUpdateEmailBroadcastModal,
+		lastSelectedItem,
+		showCreateModal,
+		showUpdateModal,
+		setShowCreateModal,
+		setShowUpdateModal,
 		focusGridList,
 	} = useEmailBroadcastsContext();
 
@@ -83,11 +83,10 @@ export function CreateOrUpdateEmailBroadcastModal({
 	});
 
 	const { form, onSubmit } = useCreateOrUpdateForm({
-		updateItem: mode === 'create' ? null : selectedEmailBroadcast ?? null,
+		updateItem: mode === 'create' ? null : lastSelectedItem ?? null,
 		upsertSchema: upsertEmailBroadcastSchema,
 		defaultValues: {
-			emailTemplateId:
-				mode === 'update' ? selectedEmailBroadcast?.emailTemplateId ?? '' : '',
+			emailTemplateId: mode === 'update' ? lastSelectedItem?.emailTemplateId ?? '' : '',
 			fanGroupId: null,
 			status: 'draft',
 			scheduledAt: null,
@@ -140,12 +139,9 @@ export function CreateOrUpdateEmailBroadcastModal({
 		return onSubmit(d);
 	};
 
-	const showEmailBroadcastModal =
-		mode === 'create' ? showCreateEmailBroadcastModal : showUpdateEmailBroadcastModal;
+	const showEmailBroadcastModal = mode === 'create' ? showCreateModal : showUpdateModal;
 	const setShowEmailBroadcastModal =
-		mode === 'create' ?
-			setShowCreateEmailBroadcastModal
-		:	setShowUpdateEmailBroadcastModal;
+		mode === 'create' ? setShowCreateModal : setShowUpdateModal;
 
 	const handleCloseModal = useCallback(async () => {
 		focusGridList();
@@ -182,12 +178,10 @@ export function CreateOrUpdateEmailBroadcastModal({
 					{/* <pre>{JSON.stringify(!canEdit, null, 2)}</pre> */}
 					{!canEdit && (
 						<div className='flex flex-col items-center justify-center gap-2'>
-							<Text variant='md/semibold'>
-								{selectedEmailBroadcast?.emailTemplate.name}
-							</Text>
+							<Text variant='md/semibold'>{lastSelectedItem?.emailTemplate.name}</Text>
 							<div className='flex flex-row items-center justify-center gap-2'>
 								<Icon.send className='h-4 w-4' />
-								<span>Sent @{selectedEmailBroadcast?.sentAt?.toLocaleString()}</span>
+								<span>Sent @{lastSelectedItem?.sentAt?.toLocaleString()}</span>
 							</div>
 						</div>
 					)}

--- a/apps/app/src/app/[handle]/email-template-groups/_components/all-email-template-groups.tsx
+++ b/apps/app/src/app/[handle]/email-template-groups/_components/all-email-template-groups.tsx
@@ -4,6 +4,7 @@ import type { AppRouterOutputs } from '@barely/lib/server/api/router';
 import { useWorkspace } from '@barely/lib/hooks/use-workspace';
 import { api } from '@barely/lib/server/api/react';
 
+import { GridListSkeleton } from '@barely/ui/components/grid-list-skeleton';
 import { NoResultsPlaceholder } from '@barely/ui/components/no-results-placeholder';
 import { Button } from '@barely/ui/elements/button';
 import { GridList, GridListCard } from '@barely/ui/elements/grid-list';
@@ -14,12 +15,13 @@ import { useEmailTemplateGroupContext } from './email-template-group-context';
 
 export function AllEmailTemplateGroups() {
 	const {
-		emailTemplateGroups,
-		emailTemplateGroupSelection,
-		lastSelectedEmailTemplateGroupId,
-		setEmailTemplateGroupSelection,
+		items,
+		selection,
+		lastSelectedItemId,
+		setSelection,
 		gridListRef,
-		setShowUpdateEmailTemplateGroupModal,
+		setShowUpdateModal,
+		isFetching,
 	} = useEmailTemplateGroupContext();
 
 	return (
@@ -31,26 +33,26 @@ export function AllEmailTemplateGroups() {
 				selectionMode='multiple'
 				selectionBehavior='replace'
 				onAction={() => {
-					if (!lastSelectedEmailTemplateGroupId) return;
-					setShowUpdateEmailTemplateGroupModal(true);
+					if (!lastSelectedItemId) return;
+					setShowUpdateModal(true);
 				}}
-				items={emailTemplateGroups}
-				selectedKeys={emailTemplateGroupSelection}
-				setSelectedKeys={setEmailTemplateGroupSelection}
-				renderEmptyState={() => (
-					<NoResultsPlaceholder
-						icon='emailTemplateGroup'
-						title='No Email Template Groups'
-						subtitle='Create a new email template group to get started.'
-						button={<CreateEmailTemplateGroupButton />}
-					/>
-				)}
+				items={items}
+				selectedKeys={selection}
+				setSelectedKeys={setSelection}
+				renderEmptyState={() =>
+					isFetching ?
+						<GridListSkeleton />
+					:	<NoResultsPlaceholder
+							icon='emailTemplateGroup'
+							title='No Email Template Groups'
+							subtitle='Create a new email template group to get started.'
+							button={<CreateEmailTemplateGroupButton />}
+						/>
+				}
 			>
-				{emailTemplateGroup => (
-					<EmailTemplateGroupCard emailTemplateGroup={emailTemplateGroup} />
-				)}
+				{item => <EmailTemplateGroupCard emailTemplateGroup={item} />}
 			</GridList>
-			<LoadMoreButton />
+			{!!items.length && <LoadMoreButton />}
 		</div>
 	);
 }
@@ -81,8 +83,7 @@ function EmailTemplateGroupCard({
 }: {
 	emailTemplateGroup: AppRouterOutputs['emailTemplateGroup']['byWorkspace']['emailTemplateGroups'][0];
 }) {
-	const { setShowUpdateEmailTemplateGroupModal, setShowDeleteEmailTemplateGroupModal } =
-		useEmailTemplateGroupContext();
+	const { setShowUpdateModal, setShowDeleteModal } = useEmailTemplateGroupContext();
 
 	const { handle } = useWorkspace();
 
@@ -102,8 +103,8 @@ function EmailTemplateGroupCard({
 			id={emailTemplateGroup.id}
 			key={emailTemplateGroup.id}
 			textValue={emailTemplateGroup.name}
-			setShowUpdateModal={setShowUpdateEmailTemplateGroupModal}
-			setShowDeleteModal={setShowDeleteEmailTemplateGroupModal}
+			setShowUpdateModal={setShowUpdateModal}
+			setShowDeleteModal={setShowDeleteModal}
 		>
 			<div className='flex flex-grow flex-row items-center gap-4'>
 				<div className='flex flex-col gap-1'>

--- a/apps/app/src/app/[handle]/email-template-groups/_components/archive-or-delete-email-template-group-modal.tsx
+++ b/apps/app/src/app/[handle]/email-template-groups/_components/archive-or-delete-email-template-group-modal.tsx
@@ -12,25 +12,19 @@ export function ArchiveOrDeleteEmailTemplateGroupModal({
 	mode: 'archive' | 'delete';
 }) {
 	const {
-		emailTemplateGroupSelection,
-		lastSelectedEmailTemplateGroup,
-		showArchiveEmailTemplateGroupModal,
-		showDeleteEmailTemplateGroupModal,
-		setShowArchiveEmailTemplateGroupModal,
-		setShowDeleteEmailTemplateGroupModal,
+		selection,
+		lastSelectedItem,
+		showArchiveModal,
+		showDeleteModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
 	} = useEmailTemplateGroupContext();
 
 	const apiUtils = api.useUtils();
 
-	const showModal =
-		mode === 'archive' ?
-			showArchiveEmailTemplateGroupModal
-		:	showDeleteEmailTemplateGroupModal;
+	const showModal = mode === 'archive' ? showArchiveModal : showDeleteModal;
 
-	const setShowModal =
-		mode === 'archive' ?
-			setShowArchiveEmailTemplateGroupModal
-		:	setShowDeleteEmailTemplateGroupModal;
+	const setShowModal = mode === 'archive' ? setShowArchiveModal : setShowDeleteModal;
 
 	const onSuccess = useCallback(async () => {
 		await apiUtils.emailTemplateGroup.invalidate();
@@ -45,15 +39,15 @@ export function ArchiveOrDeleteEmailTemplateGroupModal({
 			onSuccess,
 		});
 
-	if (!lastSelectedEmailTemplateGroup) return null;
+	if (!lastSelectedItem) return null;
 
 	return (
 		<ArchiveOrDeleteModal
 			mode={mode}
-			selection={emailTemplateGroupSelection}
+			selection={selection}
 			lastSelected={{
-				...lastSelectedEmailTemplateGroup,
-				name: lastSelectedEmailTemplateGroup.name,
+				...lastSelectedItem,
+				name: lastSelectedItem.name,
 			}}
 			showModal={showModal}
 			setShowModal={setShowModal}

--- a/apps/app/src/app/[handle]/email-template-groups/_components/create-email-template-group-button.tsx
+++ b/apps/app/src/app/[handle]/email-template-groups/_components/create-email-template-group-button.tsx
@@ -5,12 +5,12 @@ import { Button } from '@barely/ui/elements/button';
 import { useEmailTemplateGroupContext } from './email-template-group-context';
 
 export function CreateEmailTemplateGroupButton() {
-	const { setShowCreateEmailTemplateGroupModal } = useEmailTemplateGroupContext();
+	const { setShowCreateModal } = useEmailTemplateGroupContext();
 
 	return (
 		<Button
 			onClick={() => {
-				setShowCreateEmailTemplateGroupModal(true);
+				setShowCreateModal(true);
 			}}
 			className='space-x-3'
 		>

--- a/apps/app/src/app/[handle]/email-template-groups/_components/create-or-update-email-template-group-modal.tsx
+++ b/apps/app/src/app/[handle]/email-template-groups/_components/create-or-update-email-template-group-modal.tsx
@@ -25,11 +25,11 @@ export function CreateOrUpdateEmailTemplateGroupModal({
 	const apiUtils = api.useUtils();
 
 	const {
-		lastSelectedEmailTemplateGroup: selectedEmailTemplateGroup,
-		showCreateEmailTemplateGroupModal,
-		showUpdateEmailTemplateGroupModal,
-		setShowCreateEmailTemplateGroupModal,
-		setShowUpdateEmailTemplateGroupModal,
+		lastSelectedItem,
+		showCreateModal,
+		showUpdateModal,
+		setShowCreateModal,
+		setShowUpdateModal,
 		focusGridList,
 	} = useEmailTemplateGroupContext();
 
@@ -38,7 +38,7 @@ export function CreateOrUpdateEmailTemplateGroupModal({
 	const { data: selectedEmailTemplates } = api.emailTemplateGroup.byId.useQuery(
 		{
 			handle,
-			id: selectedEmailTemplateGroup?.id ?? '',
+			id: lastSelectedItem?.id ?? '',
 		},
 		{
 			select: data => data.emailTemplates,
@@ -75,17 +75,17 @@ export function CreateOrUpdateEmailTemplateGroupModal({
 	const { form, onSubmit } = useCreateOrUpdateForm({
 		updateItem:
 			mode === 'create' ? null
-			: selectedEmailTemplateGroup ?
+			: lastSelectedItem ?
 				{
-					...selectedEmailTemplateGroup,
+					...lastSelectedItem,
 					emailTemplates: selectedEmailTemplates ?? [],
 				}
 			:	null,
 		upsertSchema: upsertEmailTemplateGroupSchema,
 		// mode === 'create' ? createEmailTemplateGroupSchema : updateEmailTemplateGroupSchema,
 		defaultValues: {
-			name: mode === 'update' ? selectedEmailTemplateGroup?.name ?? '' : '',
-			description: mode === 'update' ? selectedEmailTemplateGroup?.description ?? '' : '',
+			name: mode === 'update' ? lastSelectedItem?.name ?? '' : '',
+			description: mode === 'update' ? lastSelectedItem?.description ?? '' : '',
 			emailTemplates: mode === 'update' ? selectedEmailTemplates ?? [] : [],
 		},
 		handleCreateItem: async d => {
@@ -125,14 +125,8 @@ export function CreateOrUpdateEmailTemplateGroupModal({
 			eto => !activeEmailTemplates.some(aet => aet.id === eto.id),
 		) ?? [];
 
-	const showModal =
-		mode === 'create' ?
-			showCreateEmailTemplateGroupModal
-		:	showUpdateEmailTemplateGroupModal;
-	const setShowModal =
-		mode === 'create' ?
-			setShowCreateEmailTemplateGroupModal
-		:	setShowUpdateEmailTemplateGroupModal;
+	const showModal = mode === 'create' ? showCreateModal : showUpdateModal;
+	const setShowModal = mode === 'create' ? setShowCreateModal : setShowUpdateModal;
 
 	const handleCloseModal = useCallback(async () => {
 		focusGridList();
@@ -161,7 +155,7 @@ export function CreateOrUpdateEmailTemplateGroupModal({
 				icon='emails'
 				title={
 					mode === 'update' ?
-						`Update ${selectedEmailTemplateGroup?.name ?? ''}`
+						`Update ${lastSelectedItem?.name ?? ''}`
 					:	'Create Email Template Group'
 				}
 			/>

--- a/apps/app/src/app/[handle]/email-template-groups/_components/email-template-group-hotkeys.tsx
+++ b/apps/app/src/app/[handle]/email-template-groups/_components/email-template-group-hotkeys.tsx
@@ -6,20 +6,19 @@ import { useEmailTemplateGroupContext } from './email-template-group-context';
 
 export function EmailTemplateGroupHotkeys() {
 	const {
-		emailTemplateGroupSelection,
-		setShowCreateEmailTemplateGroupModal,
-		setShowUpdateEmailTemplateGroupModal,
-		setShowArchiveEmailTemplateGroupModal,
-		setShowDeleteEmailTemplateGroupModal,
+		selection,
+		setShowCreateModal,
+		setShowUpdateModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
 	} = useEmailTemplateGroupContext();
 
 	useModalHotKeys({
-		setShowCreateModal: setShowCreateEmailTemplateGroupModal,
-		setShowUpdateModal: setShowUpdateEmailTemplateGroupModal,
-		setShowArchiveModal: setShowArchiveEmailTemplateGroupModal,
-		setShowDeleteModal: setShowDeleteEmailTemplateGroupModal,
-		itemSelected:
-			emailTemplateGroupSelection !== 'all' && !!emailTemplateGroupSelection.size,
+		setShowCreateModal,
+		setShowUpdateModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
+		itemSelected: selection !== 'all' && !!selection.size,
 	});
 
 	return null;

--- a/apps/app/src/app/[handle]/email-templates/_components/all-email-templates.tsx
+++ b/apps/app/src/app/[handle]/email-templates/_components/all-email-templates.tsx
@@ -3,6 +3,7 @@
 import type { AppRouterOutputs } from '@barely/lib/server/api/router';
 import { formatCentsToDollars } from '@barely/lib/utils/currency';
 
+import { GridListSkeleton } from '@barely/ui/components/grid-list-skeleton';
 import { NoResultsPlaceholder } from '@barely/ui/components/no-results-placeholder';
 import { Button } from '@barely/ui/elements/button';
 import { GridList, GridListCard } from '@barely/ui/elements/grid-list';
@@ -13,12 +14,13 @@ import { useEmailTemplateContext } from './email-template-context';
 
 export function AllEmailTemplates() {
 	const {
-		emailTemplates,
-		emailTemplateSelection,
-		lastSelectedEmailTemplateId,
-		setEmailTemplateSelection,
+		items,
+		selection,
+		lastSelectedItemId,
+		setSelection,
 		gridListRef,
-		setShowUpdateEmailTemplateModal,
+		setShowUpdateModal,
+		isFetching,
 	} = useEmailTemplateContext();
 
 	return (
@@ -30,24 +32,26 @@ export function AllEmailTemplates() {
 				selectionMode='multiple'
 				selectionBehavior='replace'
 				onAction={() => {
-					if (!lastSelectedEmailTemplateId) return;
-					setShowUpdateEmailTemplateModal(true);
+					if (!lastSelectedItemId) return;
+					setShowUpdateModal(true);
 				}}
-				items={emailTemplates}
-				selectedKeys={emailTemplateSelection}
-				setSelectedKeys={setEmailTemplateSelection}
-				renderEmptyState={() => (
-					<NoResultsPlaceholder
-						icon='email'
-						title='No Email Templates'
-						subtitle='Create a new email template to get started.'
-						button={<CreateEmailTemplateButton />}
-					/>
-				)}
+				items={items}
+				selectedKeys={selection}
+				setSelectedKeys={setSelection}
+				renderEmptyState={() =>
+					isFetching ?
+						<GridListSkeleton />
+					:	<NoResultsPlaceholder
+							icon='email'
+							title='No Email Templates'
+							subtitle='Create a new email template to get started.'
+							button={<CreateEmailTemplateButton />}
+						/>
+				}
 			>
 				{emailTemplate => <EmailTemplateCard emailTemplate={emailTemplate} />}
 			</GridList>
-			<LoadMoreButton />
+			{!!items.length && <LoadMoreButton />}
 		</div>
 	);
 }
@@ -77,8 +81,7 @@ function EmailTemplateCard({
 }: {
 	emailTemplate: AppRouterOutputs['emailTemplate']['byWorkspace']['emailTemplates'][0];
 }) {
-	const { setShowUpdateEmailTemplateModal, setShowDeleteEmailTemplateModal } =
-		useEmailTemplateContext();
+	const { setShowUpdateModal, setShowDeleteModal } = useEmailTemplateContext();
 
 	const { name, subject, opens, clicks, value } = emailTemplate;
 
@@ -87,8 +90,8 @@ function EmailTemplateCard({
 			id={emailTemplate.id}
 			key={emailTemplate.id}
 			textValue={emailTemplate.name}
-			setShowUpdateModal={setShowUpdateEmailTemplateModal}
-			setShowDeleteModal={setShowDeleteEmailTemplateModal}
+			setShowUpdateModal={setShowUpdateModal}
+			setShowDeleteModal={setShowDeleteModal}
 			title={name}
 			subtitle={subject}
 			stats={[

--- a/apps/app/src/app/[handle]/email-templates/_components/archive-or-delete-email-template-modal.tsx
+++ b/apps/app/src/app/[handle]/email-templates/_components/archive-or-delete-email-template-modal.tsx
@@ -12,23 +12,19 @@ export function ArchiveOrDeleteEmailTemplateModal({
 	mode: 'archive' | 'delete';
 }) {
 	const {
-		emailTemplateSelection,
-		lastSelectedEmailTemplate,
-		showArchiveEmailTemplateModal,
-		showDeleteEmailTemplateModal,
-		setShowArchiveEmailTemplateModal,
-		setShowDeleteEmailTemplateModal,
+		selection,
+		lastSelectedItem,
+		showArchiveModal,
+		showDeleteModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
 	} = useEmailTemplateContext();
 
 	const apiUtils = api.useUtils();
 
-	const showModal =
-		mode === 'archive' ? showArchiveEmailTemplateModal : showDeleteEmailTemplateModal;
+	const showModal = mode === 'archive' ? showArchiveModal : showDeleteModal;
 
-	const setShowModal =
-		mode === 'archive' ?
-			setShowArchiveEmailTemplateModal
-		:	setShowDeleteEmailTemplateModal;
+	const setShowModal = mode === 'archive' ? setShowArchiveModal : setShowDeleteModal;
 
 	const onSuccess = useCallback(async () => {
 		await apiUtils.emailTemplate.invalidate();
@@ -43,15 +39,15 @@ export function ArchiveOrDeleteEmailTemplateModal({
 			onSuccess,
 		});
 
-	if (!lastSelectedEmailTemplate) return null;
+	if (!lastSelectedItem) return null;
 
 	return (
 		<ArchiveOrDeleteModal
 			mode={mode}
-			selection={emailTemplateSelection}
+			selection={selection}
 			lastSelected={{
-				...lastSelectedEmailTemplate,
-				name: lastSelectedEmailTemplate.name,
+				...lastSelectedItem,
+				name: lastSelectedItem.name,
 			}}
 			showModal={showModal}
 			setShowModal={setShowModal}

--- a/apps/app/src/app/[handle]/email-templates/_components/create-email-template-button.tsx
+++ b/apps/app/src/app/[handle]/email-templates/_components/create-email-template-button.tsx
@@ -5,12 +5,12 @@ import { Button } from '@barely/ui/elements/button';
 import { useEmailTemplateContext } from './email-template-context';
 
 export function CreateEmailTemplateButton() {
-	const { setShowCreateEmailTemplateModal } = useEmailTemplateContext();
+	const { setShowCreateModal } = useEmailTemplateContext();
 
 	return (
 		<Button
 			onClick={() => {
-				setShowCreateEmailTemplateModal(true);
+				setShowCreateModal(true);
 			}}
 			className='space-x-3'
 		>

--- a/apps/app/src/app/[handle]/email-templates/_components/create-or-update-email-template-modal.tsx
+++ b/apps/app/src/app/[handle]/email-templates/_components/create-or-update-email-template-modal.tsx
@@ -28,11 +28,11 @@ export function CreateOrUpdateEmailTemplateModal({
 	const apiUtils = api.useUtils();
 
 	const {
-		lastSelectedEmailTemplate: selectedEmailTemplate,
-		showCreateEmailTemplateModal,
-		showUpdateEmailTemplateModal,
-		setShowCreateEmailTemplateModal,
-		setShowUpdateEmailTemplateModal,
+		lastSelectedItem,
+		showCreateModal,
+		showUpdateModal,
+		setShowCreateModal,
+		setShowUpdateModal,
 		focusGridList,
 	} = useEmailTemplateContext();
 
@@ -62,15 +62,15 @@ export function CreateOrUpdateEmailTemplateModal({
 	});
 
 	const { form, onSubmit } = useCreateOrUpdateForm({
-		updateItem: mode === 'create' ? null : selectedEmailTemplate ?? null,
+		updateItem: mode === 'create' ? null : lastSelectedItem ?? null,
 		upsertSchema: upsertEmailTemplateSchema,
 		// mode === 'create' ? createEmailTemplateSchema : updateEmailTemplateSchema,
 		defaultValues: {
-			name: mode === 'update' ? selectedEmailTemplate?.name ?? '' : '',
-			subject: mode === 'update' ? selectedEmailTemplate?.subject ?? '' : '',
-			previewText: mode === 'update' ? selectedEmailTemplate?.previewText ?? '' : '',
-			body: mode === 'update' ? selectedEmailTemplate?.body ?? '' : '',
-			fromId: mode === 'update' ? selectedEmailTemplate?.fromId ?? '' : '',
+			name: mode === 'update' ? lastSelectedItem?.name ?? '' : '',
+			subject: mode === 'update' ? lastSelectedItem?.subject ?? '' : '',
+			previewText: mode === 'update' ? lastSelectedItem?.previewText ?? '' : '',
+			body: mode === 'update' ? lastSelectedItem?.body ?? '' : '',
+			fromId: mode === 'update' ? lastSelectedItem?.fromId ?? '' : '',
 		},
 		handleCreateItem: async d => {
 			await createEmailTemplate(d);
@@ -80,10 +80,9 @@ export function CreateOrUpdateEmailTemplateModal({
 		},
 	});
 
-	const showEmailTemplateModal =
-		mode === 'create' ? showCreateEmailTemplateModal : showUpdateEmailTemplateModal;
+	const showEmailTemplateModal = mode === 'create' ? showCreateModal : showUpdateModal;
 	const setShowEmailTemplateModal =
-		mode === 'create' ? setShowCreateEmailTemplateModal : setShowUpdateEmailTemplateModal;
+		mode === 'create' ? setShowCreateModal : setShowUpdateModal;
 
 	const handleCloseModal = useCallback(async () => {
 		focusGridList();
@@ -105,7 +104,7 @@ export function CreateOrUpdateEmailTemplateModal({
 				icon='email'
 				title={
 					mode === 'update' ?
-						`Update ${selectedEmailTemplate?.name ?? ''}`
+						`Update ${lastSelectedItem?.name ?? ''}`
 					:	'Create Email Template'
 				}
 			/>

--- a/apps/app/src/app/[handle]/email-templates/_components/email-template-context.tsx
+++ b/apps/app/src/app/[handle]/email-templates/_components/email-template-context.tsx
@@ -2,7 +2,7 @@
 
 import type { AppRouterOutputs } from '@barely/lib/server/api/react';
 import type { emailTemplateFilterParamsSchema } from '@barely/lib/server/routes/email-template/email-template.schema';
-import type { FetchNextPageOptions } from '@tanstack/react-query';
+// import type { FetchNextPageOptions } from '@tanstack/react-query';
 import type { Selection } from 'react-aria-components';
 import type { z } from 'zod';
 import { createContext, use, useCallback, useContext, useRef, useState } from 'react';
@@ -11,35 +11,45 @@ import { useWorkspace } from '@barely/lib/hooks/use-workspace';
 import { api } from '@barely/lib/server/api/react';
 import { emailTemplateSearchParamsSchema } from '@barely/lib/server/routes/email-template/email-template.schema';
 
-interface EmailTemplateContext {
-	emailTemplates: AppRouterOutputs['emailTemplate']['byWorkspace']['emailTemplates'];
-	emailTemplateSelection: Selection;
-	lastSelectedEmailTemplateId: string | undefined;
-	lastSelectedEmailTemplate:
-		| AppRouterOutputs['emailTemplate']['byWorkspace']['emailTemplates'][number]
-		| undefined;
-	setEmailTemplateSelection: (selection: Selection) => void;
-	gridListRef: React.RefObject<HTMLDivElement>;
-	focusGridList: () => void;
-	showCreateEmailTemplateModal: boolean;
-	setShowCreateEmailTemplateModal: (show: boolean) => void;
-	showUpdateEmailTemplateModal: boolean;
-	setShowUpdateEmailTemplateModal: (show: boolean) => void;
-	showDeleteEmailTemplateModal: boolean;
-	setShowDeleteEmailTemplateModal: (show: boolean) => void;
-	showArchiveEmailTemplateModal: boolean;
-	setShowArchiveEmailTemplateModal: (show: boolean) => void;
-	// filters
-	filters: z.infer<typeof emailTemplateFilterParamsSchema>;
-	pendingFiltersTransition: boolean;
-	setSearch: (search: string) => void;
-	toggleArchived: () => void;
-	clearAllFilters: () => void;
-	// infinite
-	hasNextPage: boolean;
-	fetchNextPage: (options?: FetchNextPageOptions) => void | Promise<void>;
-	isFetchingNextPage: boolean;
-}
+import type { InfiniteItemsContext } from '~/app/[handle]/_types/all-items-context';
+
+// interface EmailTemplateContext {
+// 	// emailTemplates: AppRouterOutputs['emailTemplate']['byWorkspace']['emailTemplates'];
+// 	// emailTemplateSelection: Selection;
+// 	// lastSelectedEmailTemplateId: string | undefined;
+// 	// lastSelectedEmailTemplate:
+// 	// 	| AppRouterOutputs['emailTemplate']['byWorkspace']['emailTemplates'][number]
+// 	// 	| undefined;
+// 	// setEmailTemplateSelection: (selection: Selection) => void;
+// 	// gridListRef: React.RefObject<HTMLDivElement>;
+// 	// focusGridList: () => void;
+// 	// showCreateEmailTemplateModal: boolean;
+// 	// setShowCreateEmailTemplateModal: (show: boolean) => void;
+// 	// showUpdateEmailTemplateModal: boolean;
+// 	// setShowUpdateEmailTemplateModal: (show: boolean) => void;
+// 	// showDeleteEmailTemplateModal: boolean;
+// 	// setShowDeleteEmailTemplateModal: (show: boolean) => void;
+// 	// showArchiveEmailTemplateModal: boolean;
+// 	// setShowArchiveEmailTemplateModal: (show: boolean) => void;
+// 	// filters
+// 	// filters: z.infer<typeof emailTemplateFilterParamsSchema>;
+// 	// pendingFiltersTransition: boolean;
+// 	// setSearch: (search: string) => void;
+// 	// toggleArchived: () => void;
+// 	// clearAllFilters: () => void;
+// 	// infinite
+// 	// hasNextPage: boolean;
+// 	// fetchNextPage: (options?: FetchNextPageOptions) => void | Promise<void>;
+// 	// isFetchingNextPage: boolean;
+// 	// isRefetching: boolean;
+// 	// isFetching: boolean;
+// 	// isPending: boolean;
+// }
+
+type EmailTemplateContext = InfiniteItemsContext<
+	AppRouterOutputs['emailTemplate']['byWorkspace']['emailTemplates'][number],
+	z.infer<typeof emailTemplateFilterParamsSchema>
+>;
 
 const EmailTemplateContext = createContext<EmailTemplateContext | undefined>(undefined);
 
@@ -52,11 +62,11 @@ export function EmailTemplateContextProvider({
 		AppRouterOutputs['emailTemplate']['byWorkspace']
 	>;
 }) {
-	const [showCreateEmailTemplateModal, setShowCreateEmailTemplateModal] = useState(false);
-	const [showUpdateEmailTemplateModal, setShowUpdateEmailTemplateModal] = useState(false);
-	const [showDeleteEmailTemplateModal, setShowDeleteEmailTemplateModal] = useState(false);
-	const [showArchiveEmailTemplateModal, setShowArchiveEmailTemplateModal] =
-		useState(false);
+	const [showCreateModal, setShowCreateModal] = useState(false);
+	const [showUpdateModal, setShowUpdateModal] = useState(false);
+	const [showDeleteModal, setShowDeleteModal] = useState(false);
+	const [showArchiveModal, setShowArchiveModal] = useState(false);
+	useState(false);
 
 	const { handle } = useWorkspace();
 
@@ -76,6 +86,9 @@ export function EmailTemplateContextProvider({
 		hasNextPage,
 		fetchNextPage,
 		isFetchingNextPage,
+		isRefetching,
+		isFetching,
+		isPending,
 	} = api.emailTemplate.byWorkspace.useInfiniteQuery(
 		{ handle, ...filters },
 		{
@@ -138,23 +151,23 @@ export function EmailTemplateContextProvider({
 	);
 
 	const contextValue = {
-		emailTemplates,
-		emailTemplateSelection,
-		lastSelectedEmailTemplateId,
-		lastSelectedEmailTemplate,
-		setEmailTemplateSelection,
+		items: emailTemplates,
+		selection: emailTemplateSelection,
+		lastSelectedItemId: lastSelectedEmailTemplateId,
+		lastSelectedItem: lastSelectedEmailTemplate,
+		setSelection: setEmailTemplateSelection,
 		gridListRef,
 		focusGridList: () => {
 			gridListRef.current?.focus();
 		},
-		showCreateEmailTemplateModal,
-		setShowCreateEmailTemplateModal,
-		showUpdateEmailTemplateModal,
-		setShowUpdateEmailTemplateModal,
-		showDeleteEmailTemplateModal,
-		setShowDeleteEmailTemplateModal,
-		showArchiveEmailTemplateModal,
-		setShowArchiveEmailTemplateModal,
+		showCreateModal,
+		setShowCreateModal,
+		showUpdateModal,
+		setShowUpdateModal,
+		showArchiveModal,
+		setShowArchiveModal,
+		showDeleteModal,
+		setShowDeleteModal,
 		// filters
 		filters,
 		pendingFiltersTransition: pending,
@@ -165,6 +178,9 @@ export function EmailTemplateContextProvider({
 		hasNextPage,
 		fetchNextPage: () => void fetchNextPage(),
 		isFetchingNextPage,
+		isFetching,
+		isRefetching,
+		isPending,
 	} satisfies EmailTemplateContext;
 
 	return (

--- a/apps/app/src/app/[handle]/email-templates/_components/email-template-hotkeys.tsx
+++ b/apps/app/src/app/[handle]/email-templates/_components/email-template-hotkeys.tsx
@@ -6,19 +6,19 @@ import { useEmailTemplateContext } from './email-template-context';
 
 export function EmailTemplateHotkeys() {
 	const {
-		emailTemplateSelection,
-		setShowCreateEmailTemplateModal,
-		setShowUpdateEmailTemplateModal,
-		setShowArchiveEmailTemplateModal,
-		setShowDeleteEmailTemplateModal,
+		selection,
+		setShowCreateModal,
+		setShowUpdateModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
 	} = useEmailTemplateContext();
 
 	useModalHotKeys({
-		setShowCreateModal: setShowCreateEmailTemplateModal,
-		setShowUpdateModal: setShowUpdateEmailTemplateModal,
-		setShowArchiveModal: setShowArchiveEmailTemplateModal,
-		setShowDeleteModal: setShowDeleteEmailTemplateModal,
-		itemSelected: emailTemplateSelection !== 'all' && !!emailTemplateSelection.size,
+		setShowCreateModal,
+		setShowUpdateModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
+		itemSelected: selection !== 'all' && !!selection.size,
 	});
 
 	return null;

--- a/apps/app/src/app/[handle]/fan-groups/_components/all-fan-groups.tsx
+++ b/apps/app/src/app/[handle]/fan-groups/_components/all-fan-groups.tsx
@@ -4,6 +4,7 @@ import type { AppRouterOutputs } from '@barely/lib/server/api/router';
 import { useWorkspace } from '@barely/lib/hooks/use-workspace';
 import { api } from '@barely/lib/server/api/react';
 
+import { GridListSkeleton } from '@barely/ui/components/grid-list-skeleton';
 import { NoResultsPlaceholder } from '@barely/ui/components/no-results-placeholder';
 import { GridList, GridListCard } from '@barely/ui/elements/grid-list';
 import { Text } from '@barely/ui/elements/typography';
@@ -13,12 +14,13 @@ import { useFanGroupContext } from '~/app/[handle]/fan-groups/_components/fan-gr
 
 export function AllFanGroups() {
 	const {
-		fanGroups,
+		items,
+		selection,
+		lastSelectedItemId,
+		setSelection,
+		setShowUpdateModal,
 		gridListRef,
-		fanGroupSelection,
-		lastSelectedFanGroupId,
-		setFanGroupSelection,
-		setShowUpdateFanGroupModal,
+		isFetching,
 	} = useFanGroupContext();
 
 	const { handle } = useWorkspace();
@@ -37,19 +39,24 @@ export function AllFanGroups() {
 				selectionMode='multiple'
 				selectionBehavior='replace'
 				onAction={() => {
-					if (!lastSelectedFanGroupId) return;
-					setShowUpdateFanGroupModal(true);
+					if (!lastSelectedItemId) return;
+					setShowUpdateModal(true);
 				}}
-				items={fanGroups}
-				selectedKeys={fanGroupSelection}
-				setSelectedKeys={setFanGroupSelection}
+				items={items}
+				selectedKeys={selection}
+				setSelectedKeys={setSelection}
 				renderEmptyState={() => (
-					<NoResultsPlaceholder
-						icon='fanGroup'
-						title='No Fan Groups'
-						subtitle='Create a new fan group to get started.'
-						button={<CreateFanGroupButton />}
-					/>
+					<>
+						{isFetching ?
+							<GridListSkeleton />
+						:	<NoResultsPlaceholder
+								icon='fanGroup'
+								title='No Fan Groups'
+								subtitle='Create a new fan group to get started.'
+								button={<CreateFanGroupButton />}
+							/>
+						}
+					</>
 				)}
 			>
 				{fanGroup => <FanGroupCard fanGroup={fanGroup} />}
@@ -63,11 +70,8 @@ function FanGroupCard({
 }: {
 	fanGroup: AppRouterOutputs['fanGroup']['byWorkspace']['fanGroups'][0];
 }) {
-	const {
-		setShowUpdateFanGroupModal,
-		setShowArchiveFanGroupModal,
-		setShowDeleteFanGroupModal,
-	} = useFanGroupContext();
+	const { setShowUpdateModal, setShowArchiveModal, setShowDeleteModal } =
+		useFanGroupContext();
 
 	const { handle } = useWorkspace();
 	const { data: fanGroupById } = api.fanGroup.byId.useQuery({
@@ -80,9 +84,9 @@ function FanGroupCard({
 			id={fanGroup.id}
 			key={fanGroup.id}
 			textValue={fanGroup.name}
-			setShowUpdateModal={setShowUpdateFanGroupModal}
-			setShowArchiveModal={setShowArchiveFanGroupModal}
-			setShowDeleteModal={setShowDeleteFanGroupModal}
+			setShowUpdateModal={setShowUpdateModal}
+			setShowArchiveModal={setShowArchiveModal}
+			setShowDeleteModal={setShowDeleteModal}
 		>
 			<div className='flex flex-grow flex-row items-center gap-4'>
 				<div className='flex flex-col gap-1'>

--- a/apps/app/src/app/[handle]/fan-groups/_components/archive-or-delete-fan-group-modal.tsx
+++ b/apps/app/src/app/[handle]/fan-groups/_components/archive-or-delete-fan-group-modal.tsx
@@ -8,21 +8,19 @@ import { useFanGroupContext } from '~/app/[handle]/fan-groups/_components/fan-gr
 
 export function ArchiveOrDeleteFanGroupModal({ mode }: { mode: 'archive' | 'delete' }) {
 	const {
-		fanGroupSelection,
-		lastSelectedFanGroup,
-		showArchiveFanGroupModal,
-		showDeleteFanGroupModal,
-		setShowArchiveFanGroupModal,
-		setShowDeleteFanGroupModal,
+		selection,
+		lastSelectedItem,
+		showArchiveModal,
+		showDeleteModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
 	} = useFanGroupContext();
 
 	const apiUtils = api.useUtils();
 
-	const showModal =
-		mode === 'archive' ? showArchiveFanGroupModal : showDeleteFanGroupModal;
+	const showModal = mode === 'archive' ? showArchiveModal : showDeleteModal;
 
-	const setShowModal =
-		mode === 'archive' ? setShowArchiveFanGroupModal : setShowDeleteFanGroupModal;
+	const setShowModal = mode === 'archive' ? setShowArchiveModal : setShowDeleteModal;
 
 	const onSuccess = useCallback(async () => {
 		await apiUtils.fanGroup.invalidate();
@@ -35,13 +33,13 @@ export function ArchiveOrDeleteFanGroupModal({ mode }: { mode: 'archive' | 'dele
 	const { mutate: deleteFanGroups, isPending: isPendingDelete } =
 		api.fanGroup.delete.useMutation({ onSuccess });
 
-	if (!lastSelectedFanGroup) return null;
+	if (!lastSelectedItem) return null;
 
 	return (
 		<ArchiveOrDeleteModal
 			mode={mode}
-			selection={fanGroupSelection}
-			lastSelected={{ ...lastSelectedFanGroup, name: lastSelectedFanGroup.name }}
+			selection={selection}
+			lastSelected={{ ...lastSelectedItem, name: lastSelectedItem.name }}
 			showModal={showModal}
 			setShowModal={setShowModal}
 			archiveItems={archiveFanGroups}

--- a/apps/app/src/app/[handle]/fan-groups/_components/create-fan-group-button.tsx
+++ b/apps/app/src/app/[handle]/fan-groups/_components/create-fan-group-button.tsx
@@ -5,12 +5,12 @@ import { Button } from '@barely/ui/elements/button';
 import { useFanGroupContext } from '~/app/[handle]/fan-groups/_components/fan-group-context';
 
 export function CreateFanGroupButton() {
-	const { setShowCreateFanGroupModal } = useFanGroupContext();
+	const { setShowCreateModal } = useFanGroupContext();
 
 	return (
 		<Button
 			onClick={() => {
-				setShowCreateFanGroupModal(true);
+				setShowCreateModal(true);
 			}}
 			className='space-x-3'
 		>

--- a/apps/app/src/app/[handle]/fan-groups/_components/create-or-update-fan-group-modal.tsx
+++ b/apps/app/src/app/[handle]/fan-groups/_components/create-or-update-fan-group-modal.tsx
@@ -35,21 +35,21 @@ export function CreateOrUpdateFanGroupModal({ mode }: { mode: 'create' | 'update
 	const { handle } = useWorkspace();
 	/* fan group context */
 	const {
-		lastSelectedFanGroupId,
-		showCreateFanGroupModal,
-		showUpdateFanGroupModal,
-		setShowCreateFanGroupModal,
-		setShowUpdateFanGroupModal,
+		lastSelectedItemId,
+		showCreateModal,
+		showUpdateModal,
+		setShowCreateModal,
+		setShowUpdateModal,
 		focusGridList,
 	} = useFanGroupContext();
 
 	const { data: selectedFanGroup } = api.fanGroup.byId.useQuery(
 		{
-			id: lastSelectedFanGroupId ?? '',
+			id: lastSelectedItemId ?? '',
 			handle,
 		},
 		{
-			enabled: mode === 'update' && !!lastSelectedFanGroupId,
+			enabled: mode === 'update' && !!lastSelectedItemId,
 		},
 	);
 
@@ -117,17 +117,15 @@ export function CreateOrUpdateFanGroupModal({ mode }: { mode: 'create' | 'update
 	});
 
 	/* modal */
-	const showFanGroupModal =
-		mode === 'create' ? showCreateFanGroupModal : showUpdateFanGroupModal;
-	const setShowFanGroupModal =
-		mode === 'create' ? setShowCreateFanGroupModal : setShowUpdateFanGroupModal;
+	const showModal = mode === 'create' ? showCreateModal : showUpdateModal;
+	const setShowModal = mode === 'create' ? setShowCreateModal : setShowUpdateModal;
 
 	const handleCloseModal = useCallback(async () => {
 		focusGridList();
 		await apiUtils.fanGroup.invalidate();
 		form.reset();
-		setShowFanGroupModal(false);
-	}, [form, focusGridList, apiUtils.fanGroup, setShowFanGroupModal]);
+		setShowModal(false);
+	}, [form, focusGridList, apiUtils.fanGroup, setShowModal]);
 
 	/* form submit */
 	const handleSubmit = useCallback(
@@ -142,8 +140,8 @@ export function CreateOrUpdateFanGroupModal({ mode }: { mode: 'create' | 'update
 
 	return (
 		<Modal
-			showModal={showFanGroupModal}
-			setShowModal={setShowFanGroupModal}
+			showModal={showModal}
+			setShowModal={setShowModal}
 			preventDefaultClose={form.formState.isDirty}
 			onClose={handleCloseModal}
 			className='max-w-2xl'

--- a/apps/app/src/app/[handle]/fan-groups/_components/fan-group-context.tsx
+++ b/apps/app/src/app/[handle]/fan-groups/_components/fan-group-context.tsx
@@ -10,31 +10,38 @@ import { useWorkspace } from '@barely/lib/hooks/use-workspace';
 import { api } from '@barely/lib/server/api/react';
 import { fanGroupSearchParamsSchema } from '@barely/lib/server/routes/fan-group/fan-group.schema';
 
-interface FanGroupContext {
-	fanGroups: AppRouterOutputs['fanGroup']['byWorkspace']['fanGroups'];
-	fanGroupSelection: Selection;
-	lastSelectedFanGroupId: string | undefined;
-	lastSelectedFanGroup:
-		| AppRouterOutputs['fanGroup']['byWorkspace']['fanGroups'][number]
-		| undefined;
-	setFanGroupSelection: (selection: Selection) => void;
-	gridListRef: React.RefObject<HTMLDivElement>;
-	focusGridList: () => void;
-	showCreateFanGroupModal: boolean;
-	setShowCreateFanGroupModal: (show: boolean) => void;
-	showUpdateFanGroupModal: boolean;
-	setShowUpdateFanGroupModal: (show: boolean) => void;
-	showArchiveFanGroupModal: boolean;
-	setShowArchiveFanGroupModal: (show: boolean) => void;
-	showDeleteFanGroupModal: boolean;
-	setShowDeleteFanGroupModal: (show: boolean) => void;
-	// filters
-	filters: z.infer<typeof fanGroupFilterParamsSchema>;
-	pendingFiltersTransition: boolean;
-	setSearch: (search: string) => void;
-	toggleArchived: () => void;
-	clearAllFilters: () => void;
-}
+import type { InfiniteItemsContext } from '~/app/[handle]/_types/all-items-context';
+
+// interface FanGroupContext {
+// 	fanGroups: AppRouterOutputs['fanGroup']['byWorkspace']['fanGroups'];
+// 	fanGroupSelection: Selection;
+// 	lastSelectedFanGroupId: string | undefined;
+// 	lastSelectedFanGroup:
+// 		| AppRouterOutputs['fanGroup']['byWorkspace']['fanGroups'][number]
+// 		| undefined;
+// 	setFanGroupSelection: (selection: Selection) => void;
+// 	gridListRef: React.RefObject<HTMLDivElement>;
+// 	focusGridList: () => void;
+// 	showCreateFanGroupModal: boolean;
+// 	setShowCreateFanGroupModal: (show: boolean) => void;
+// 	showUpdateFanGroupModal: boolean;
+// 	setShowUpdateFanGroupModal: (show: boolean) => void;
+// 	showArchiveFanGroupModal: boolean;
+// 	setShowArchiveFanGroupModal: (show: boolean) => void;
+// 	showDeleteFanGroupModal: boolean;
+// 	setShowDeleteFanGroupModal: (show: boolean) => void;
+// 	// filters
+// 	filters: z.infer<typeof fanGroupFilterParamsSchema>;
+// 	pendingFiltersTransition: boolean;
+// 	setSearch: (search: string) => void;
+// 	toggleArchived: () => void;
+// 	clearAllFilters: () => void;
+// }
+
+type FanGroupContext = InfiniteItemsContext<
+	AppRouterOutputs['fanGroup']['byWorkspace']['fanGroups'][number],
+	z.infer<typeof fanGroupFilterParamsSchema>
+>;
 
 const FanGroupContext = createContext<FanGroupContext | undefined>(undefined);
 
@@ -45,10 +52,10 @@ export function FanGroupContextProvider({
 	children: React.ReactNode;
 	initialFanGroups: Promise<AppRouterOutputs['fanGroup']['byWorkspace']>;
 }) {
-	const [showCreateFanGroupModal, setShowCreateFanGroupModal] = useState(false);
-	const [showUpdateFanGroupModal, setShowUpdateFanGroupModal] = useState(false);
-	const [showArchiveFanGroupModal, setShowArchiveFanGroupModal] = useState(false);
-	const [showDeleteFanGroupModal, setShowDeleteFanGroupModal] = useState(false);
+	const [showCreateModal, setShowCreateModal] = useState(false);
+	const [showUpdateModal, setShowUpdateModal] = useState(false);
+	const [showArchiveModal, setShowArchiveModal] = useState(false);
+	const [showDeleteModal, setShowDeleteModal] = useState(false);
 
 	const { handle } = useWorkspace();
 
@@ -64,7 +71,14 @@ export function FanGroupContextProvider({
 
 	const initialData = use(initialFanGroups);
 
-	const { data: infiniteFanGroups } = api.fanGroup.byWorkspace.useInfiniteQuery(
+	const {
+		data: infiniteFanGroups,
+		hasNextPage,
+		fetchNextPage,
+		isPending,
+		isFetching,
+		isRefetching,
+	} = api.fanGroup.byWorkspace.useInfiniteQuery(
 		{ handle, ...filters },
 		{
 			initialData: () => {
@@ -122,29 +136,35 @@ export function FanGroupContextProvider({
 	);
 
 	const contextValue = {
-		fanGroups,
-		fanGroupSelection,
-		lastSelectedFanGroupId,
-		lastSelectedFanGroup,
-		setFanGroupSelection,
+		items: fanGroups,
+		selection: fanGroupSelection,
+		lastSelectedItemId: lastSelectedFanGroupId,
+		lastSelectedItem: lastSelectedFanGroup,
+		setSelection: setFanGroupSelection,
 		gridListRef,
 		focusGridList: () => {
 			gridListRef.current?.focus();
 		},
-		showCreateFanGroupModal,
-		setShowCreateFanGroupModal,
-		showUpdateFanGroupModal,
-		setShowUpdateFanGroupModal,
-		showArchiveFanGroupModal,
-		setShowArchiveFanGroupModal,
-		showDeleteFanGroupModal,
-		setShowDeleteFanGroupModal,
+		showCreateModal,
+		setShowCreateModal,
+		showUpdateModal,
+		setShowUpdateModal,
+		showArchiveModal,
+		setShowArchiveModal,
+		showDeleteModal,
+		setShowDeleteModal,
 		// filters
 		filters,
 		pendingFiltersTransition: pending,
 		setSearch,
 		toggleArchived,
 		clearAllFilters,
+		hasNextPage,
+		fetchNextPage: () => void fetchNextPage(),
+		isFetchingNextPage: isFetching,
+		isRefetching,
+		isPending,
+		isFetching,
 	} satisfies FanGroupContext;
 
 	return (

--- a/apps/app/src/app/[handle]/fan-groups/_components/fan-group-hotkeys.tsx
+++ b/apps/app/src/app/[handle]/fan-groups/_components/fan-group-hotkeys.tsx
@@ -6,19 +6,19 @@ import { useFanGroupContext } from '~/app/[handle]/fan-groups/_components/fan-gr
 
 export function FanGroupHotkeys() {
 	const {
-		fanGroupSelection,
-		setShowArchiveFanGroupModal,
-		setShowDeleteFanGroupModal,
-		setShowCreateFanGroupModal,
-		setShowUpdateFanGroupModal,
+		selection,
+		setShowArchiveModal,
+		setShowDeleteModal,
+		setShowCreateModal,
+		setShowUpdateModal,
 	} = useFanGroupContext();
 
 	useModalHotKeys({
-		setShowCreateModal: setShowCreateFanGroupModal,
-		setShowUpdateModal: setShowUpdateFanGroupModal,
-		setShowArchiveModal: setShowArchiveFanGroupModal,
-		setShowDeleteModal: setShowDeleteFanGroupModal,
-		itemSelected: fanGroupSelection !== 'all' && !!fanGroupSelection.size,
+		setShowCreateModal,
+		setShowUpdateModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
+		itemSelected: selection !== 'all' && !!selection.size,
 	});
 	return null;
 }

--- a/apps/app/src/app/[handle]/fans/_components/all-fans.tsx
+++ b/apps/app/src/app/[handle]/fans/_components/all-fans.tsx
@@ -2,6 +2,7 @@
 
 import type { AppRouterOutputs } from '@barely/lib/server/api/router';
 
+import { GridListSkeleton } from '@barely/ui/components/grid-list-skeleton';
 import { NoResultsPlaceholder } from '@barely/ui/components/no-results-placeholder';
 import { Button } from '@barely/ui/elements/button';
 import { GridList, GridListCard } from '@barely/ui/elements/grid-list';
@@ -12,12 +13,13 @@ import { useFanContext } from '~/app/[handle]/fans/_components/fan-context';
 
 export function AllFans() {
 	const {
-		fans,
-		fanSelection,
-		lastSelectedFanId,
-		setFanSelection,
+		items,
+		selection,
+		lastSelectedItemId,
+		setSelection,
 		gridListRef,
-		setShowUpdateFanModal,
+		setShowUpdateModal,
+		isFetching,
 	} = useFanContext();
 
 	return (
@@ -30,24 +32,29 @@ export function AllFans() {
 				selectionMode='multiple'
 				selectionBehavior='replace'
 				onAction={() => {
-					if (!lastSelectedFanId) return;
-					setShowUpdateFanModal(true);
+					if (!lastSelectedItemId) return;
+					setShowUpdateModal(true);
 				}}
-				items={fans}
-				selectedKeys={fanSelection}
-				setSelectedKeys={setFanSelection}
+				items={items}
+				selectedKeys={selection}
+				setSelectedKeys={setSelection}
 				renderEmptyState={() => (
-					<NoResultsPlaceholder
-						icon='fan'
-						title='No Fans'
-						subtitle='Create a new fan to get started.'
-						button={<CreateFanButton />}
-					/>
+					<>
+						{isFetching ?
+							<GridListSkeleton />
+						:	<NoResultsPlaceholder
+								icon='fan'
+								title='No Fans'
+								subtitle='Create a new fan to get started.'
+								button={<CreateFanButton />}
+							/>
+						}
+					</>
 				)}
 			>
-				{fan => <FanCard fan={fan} />}
+				{item => <FanCard fan={item} />}
 			</GridList>
-			<LoadMoreButton />
+			{items.length > 0 && <LoadMoreButton />}
 		</div>
 	);
 }
@@ -73,15 +80,15 @@ function LoadMoreButton() {
 }
 
 function FanCard({ fan }: { fan: AppRouterOutputs['fan']['byWorkspace']['fans'][0] }) {
-	const { setShowUpdateFanModal, setShowDeleteFanModal } = useFanContext();
+	const { setShowUpdateModal, setShowDeleteModal } = useFanContext();
 
 	return (
 		<GridListCard
 			id={fan.id}
 			key={fan.id}
 			textValue={fan.fullName}
-			setShowUpdateModal={setShowUpdateFanModal}
-			setShowDeleteModal={setShowDeleteFanModal}
+			setShowUpdateModal={setShowUpdateModal}
+			setShowDeleteModal={setShowDeleteModal}
 		>
 			<div className='flex flex-grow flex-row items-center gap-4'>
 				<div className='flex flex-col gap-1'>

--- a/apps/app/src/app/[handle]/fans/_components/archive-or-delete-fan-modal.tsx
+++ b/apps/app/src/app/[handle]/fans/_components/archive-or-delete-fan-modal.tsx
@@ -8,20 +8,19 @@ import { useFanContext } from '~/app/[handle]/fans/_components/fan-context';
 
 export function ArchiveOrDeleteFanModal({ mode }: { mode: 'archive' | 'delete' }) {
 	const {
-		fanSelection,
-		lastSelectedFan,
-		showArchiveFanModal,
-		showDeleteFanModal,
-		setShowArchiveFanModal,
-		setShowDeleteFanModal,
+		selection,
+		lastSelectedItem,
+		showArchiveModal,
+		showDeleteModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
 	} = useFanContext();
 
 	const apiUtils = api.useUtils();
 
-	const showModal = mode === 'archive' ? showArchiveFanModal : showDeleteFanModal;
+	const showModal = mode === 'archive' ? showArchiveModal : showDeleteModal;
 
-	const setShowModal =
-		mode === 'archive' ? setShowArchiveFanModal : setShowDeleteFanModal;
+	const setShowModal = mode === 'archive' ? setShowArchiveModal : setShowDeleteModal;
 
 	const onSuccess = useCallback(async () => {
 		await apiUtils.fan.invalidate();
@@ -35,13 +34,13 @@ export function ArchiveOrDeleteFanModal({ mode }: { mode: 'archive' | 'delete' }
 		onSuccess,
 	});
 
-	if (!lastSelectedFan) return null;
+	if (!lastSelectedItem) return null;
 
 	return (
 		<ArchiveOrDeleteModal
 			mode={mode}
-			selection={fanSelection}
-			lastSelected={{ ...lastSelectedFan, name: lastSelectedFan.fullName }}
+			selection={selection}
+			lastSelected={{ ...lastSelectedItem, name: lastSelectedItem.fullName }}
 			showModal={showModal}
 			setShowModal={setShowModal}
 			archiveItems={archiveFans}

--- a/apps/app/src/app/[handle]/fans/_components/create-fan-button.tsx
+++ b/apps/app/src/app/[handle]/fans/_components/create-fan-button.tsx
@@ -5,12 +5,12 @@ import { Button } from '@barely/ui/elements/button';
 import { useFanContext } from '~/app/[handle]/fans/_components/fan-context';
 
 export function CreateFanButton() {
-	const { setShowCreateFanModal } = useFanContext();
+	const { setShowCreateModal } = useFanContext();
 
 	return (
 		<Button
 			onClick={() => {
-				setShowCreateFanModal(true);
+				setShowCreateModal(true);
 			}}
 			className='space-x-3'
 		>

--- a/apps/app/src/app/[handle]/fans/_components/create-or-update-fan-modal.tsx
+++ b/apps/app/src/app/[handle]/fans/_components/create-or-update-fan-modal.tsx
@@ -18,11 +18,11 @@ export function CreateOrUpdateFanModal({ mode }: { mode: 'create' | 'update' }) 
 
 	/* fan context */
 	const {
-		lastSelectedFan: selectedFan,
-		showCreateFanModal,
-		showUpdateFanModal,
-		setShowCreateFanModal,
-		setShowUpdateFanModal,
+		lastSelectedItem: selectedFan,
+		showCreateModal,
+		showUpdateModal,
+		setShowCreateModal,
+		setShowUpdateModal,
 		focusGridList,
 	} = useFanContext();
 
@@ -56,23 +56,22 @@ export function CreateOrUpdateFanModal({ mode }: { mode: 'create' | 'update' }) 
 	});
 
 	/* modal */
-	const showFanModal = mode === 'create' ? showCreateFanModal : showUpdateFanModal;
-	const setShowFanModal =
-		mode === 'create' ? setShowCreateFanModal : setShowUpdateFanModal;
+	const showModal = mode === 'create' ? showCreateModal : showUpdateModal;
+	const setShowModal = mode === 'create' ? setShowCreateModal : setShowUpdateModal;
 
 	const handleCloseModal = useCallback(async () => {
 		focusGridList();
 		await apiUtils.fan.invalidate();
 		form.reset();
-		setShowFanModal(false);
-	}, [form, focusGridList, apiUtils.fan, setShowFanModal]);
+		setShowModal(false);
+	}, [form, focusGridList, apiUtils.fan, setShowModal]);
 
 	const submitDisabled = mode === 'update' && !form.formState.isDirty;
 
 	return (
 		<Modal
-			showModal={showFanModal}
-			setShowModal={setShowFanModal}
+			showModal={showModal}
+			setShowModal={setShowModal}
 			preventDefaultClose={form.formState.isDirty}
 			onClose={handleCloseModal}
 		>

--- a/apps/app/src/app/[handle]/fans/_components/fan-context.tsx
+++ b/apps/app/src/app/[handle]/fans/_components/fan-context.tsx
@@ -2,7 +2,6 @@
 
 import type { AppRouterOutputs } from '@barely/lib/server/api/react';
 import type { fanFilterParamsSchema } from '@barely/lib/server/routes/fan/fan.schema';
-import type { FetchNextPageOptions } from '@tanstack/react-query';
 import type { Selection } from 'react-aria-components';
 import type { z } from 'zod';
 import { createContext, use, useCallback, useContext, useRef, useState } from 'react';
@@ -11,33 +10,12 @@ import { useWorkspace } from '@barely/lib/hooks/use-workspace';
 import { api } from '@barely/lib/server/api/react';
 import { fanSearchParamsSchema } from '@barely/lib/server/routes/fan/fan.schema';
 
-interface FanContext {
-	fans: AppRouterOutputs['fan']['byWorkspace']['fans'];
-	fanSelection: Selection;
-	lastSelectedFanId: string | undefined;
-	lastSelectedFan: AppRouterOutputs['fan']['byWorkspace']['fans'][number] | undefined;
-	setFanSelection: (selection: Selection) => void;
-	gridListRef: React.RefObject<HTMLDivElement>;
-	focusGridList: () => void;
-	showCreateFanModal: boolean;
-	setShowCreateFanModal: (show: boolean) => void;
-	showUpdateFanModal: boolean;
-	setShowUpdateFanModal: (show: boolean) => void;
-	showDeleteFanModal: boolean;
-	setShowDeleteFanModal: (show: boolean) => void;
-	showArchiveFanModal: boolean;
-	setShowArchiveFanModal: (show: boolean) => void;
-	// filters
-	filters: z.infer<typeof fanFilterParamsSchema>;
-	pendingFiltersTransition: boolean;
-	setSearch: (search: string) => void;
-	toggleArchived: () => void;
-	clearAllFilters: () => void;
-	// infinite
-	hasNextPage: boolean;
-	fetchNextPage: (options?: FetchNextPageOptions) => void | Promise<void>;
-	isFetchingNextPage: boolean;
-}
+import type { InfiniteItemsContext } from '~/app/[handle]/_types/all-items-context';
+
+type FanContext = InfiniteItemsContext<
+	AppRouterOutputs['fan']['byWorkspace']['fans'][number],
+	z.infer<typeof fanFilterParamsSchema>
+>;
 
 const FanContext = createContext<FanContext | undefined>(undefined);
 
@@ -48,10 +26,10 @@ export function FanContextProvider({
 	children: React.ReactNode;
 	initialFansFirstPage: Promise<AppRouterOutputs['fan']['byWorkspace']>;
 }) {
-	const [showCreateFanModal, setShowCreateFanModal] = useState(false);
-	const [showUpdateFanModal, setShowUpdateFanModal] = useState(false);
-	const [showDeleteFanModal, setShowDeleteFanModal] = useState(false);
-	const [showArchiveFanModal, setShowArchiveFanModal] = useState(false);
+	const [showCreateModal, setShowCreateModal] = useState(false);
+	const [showUpdateModal, setShowUpdateModal] = useState(false);
+	const [showDeleteModal, setShowDeleteModal] = useState(false);
+	const [showArchiveModal, setShowArchiveModal] = useState(false);
 
 	const { handle } = useWorkspace();
 
@@ -71,6 +49,9 @@ export function FanContextProvider({
 		hasNextPage,
 		fetchNextPage,
 		isFetchingNextPage,
+		isFetching,
+		isRefetching,
+		isPending,
 	} = api.fan.byWorkspace.useInfiniteQuery(
 		{ handle, ...filters },
 		{
@@ -125,23 +106,23 @@ export function FanContextProvider({
 	const lastSelectedFan = fans.find(fan => fan.id === lastSelectedFanId);
 
 	const contextValue = {
-		fans,
-		fanSelection,
-		lastSelectedFanId,
-		lastSelectedFan,
-		setFanSelection,
+		items: fans,
+		selection: fanSelection,
+		lastSelectedItemId: lastSelectedFanId,
+		lastSelectedItem: lastSelectedFan,
+		setSelection: setFanSelection,
 		gridListRef,
 		focusGridList: () => {
 			gridListRef.current?.focus();
 		},
-		showCreateFanModal,
-		setShowCreateFanModal,
-		showUpdateFanModal,
-		setShowUpdateFanModal,
-		showDeleteFanModal,
-		setShowDeleteFanModal,
-		showArchiveFanModal,
-		setShowArchiveFanModal,
+		showCreateModal,
+		setShowCreateModal,
+		showUpdateModal,
+		setShowUpdateModal,
+		showDeleteModal,
+		setShowDeleteModal,
+		showArchiveModal,
+		setShowArchiveModal,
 		// filters
 		filters,
 		pendingFiltersTransition: pending,
@@ -152,6 +133,9 @@ export function FanContextProvider({
 		hasNextPage,
 		fetchNextPage: () => void fetchNextPage(),
 		isFetchingNextPage,
+		isFetching,
+		isRefetching,
+		isPending,
 	} satisfies FanContext;
 
 	return <FanContext.Provider value={contextValue}>{children}</FanContext.Provider>;

--- a/apps/app/src/app/[handle]/fans/_components/fan-hotkeys.tsx
+++ b/apps/app/src/app/[handle]/fans/_components/fan-hotkeys.tsx
@@ -6,19 +6,19 @@ import { useFanContext } from '~/app/[handle]/fans/_components/fan-context';
 
 export function FanHotkeys() {
 	const {
-		fanSelection,
-		setShowArchiveFanModal,
-		setShowDeleteFanModal,
-		setShowCreateFanModal,
-		setShowUpdateFanModal,
+		selection,
+		setShowArchiveModal,
+		setShowDeleteModal,
+		setShowCreateModal,
+		setShowUpdateModal,
 	} = useFanContext();
 
 	useModalHotKeys({
-		setShowCreateModal: setShowCreateFanModal,
-		setShowUpdateModal: setShowUpdateFanModal,
-		setShowArchiveModal: setShowArchiveFanModal,
-		setShowDeleteModal: setShowDeleteFanModal,
-		itemSelected: fanSelection !== 'all' && !!fanSelection.size,
+		setShowCreateModal,
+		setShowUpdateModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
+		itemSelected: selection !== 'all' && !!selection.size,
 	});
 	return null;
 }

--- a/apps/app/src/app/[handle]/fm/_components/all-fm-pages.tsx
+++ b/apps/app/src/app/[handle]/fm/_components/all-fm-pages.tsx
@@ -2,6 +2,7 @@
 
 import type { AppRouterOutputs } from '@barely/lib/server/api/router';
 
+import { GridListSkeleton } from '@barely/ui/components/grid-list-skeleton';
 import { NoResultsPlaceholder } from '@barely/ui/components/no-results-placeholder';
 import { GridList, GridListCard } from '@barely/ui/elements/grid-list';
 
@@ -10,12 +11,13 @@ import { useFmContext } from '~/app/[handle]/fm/_components/fm-context';
 
 export function AllFmPages() {
 	const {
-		fmPages,
-		fmPageSelection,
-		lastSelectedFmPageId,
-		setFmPageSelection,
+		items,
+		selection,
+		lastSelectedItemId,
+		setSelection,
 		gridListRef,
-		setShowUpdateFmPageModal,
+		setShowUpdateModal,
+		isFetching,
 	} = useFmContext();
 
 	return (
@@ -27,22 +29,27 @@ export function AllFmPages() {
 				selectionMode='multiple'
 				selectionBehavior='replace'
 				onAction={() => {
-					if (!lastSelectedFmPageId) return;
-					setShowUpdateFmPageModal(true);
+					if (!lastSelectedItemId) return;
+					setShowUpdateModal(true);
 				}}
-				items={fmPages}
-				selectedKeys={fmPageSelection}
-				setSelectedKeys={setFmPageSelection}
+				items={items}
+				selectedKeys={selection}
+				setSelectedKeys={setSelection}
 				renderEmptyState={() => (
-					<NoResultsPlaceholder
-						icon='fm'
-						title='No FM Pages'
-						subtitle='Create a new fm page to get started.'
-						button={<CreateFmPageButton />}
-					/>
+					<>
+						{isFetching ?
+							<GridListSkeleton />
+						:	<NoResultsPlaceholder
+								icon='fm'
+								title='No FM Pages'
+								subtitle='Create a new fm page to get started.'
+								button={<CreateFmPageButton />}
+							/>
+						}
+					</>
 				)}
 			>
-				{fmPage => <FmPageCard fmPage={fmPage} />}
+				{item => <FmPageCard fmPage={item} />}
 			</GridList>
 		</>
 	);
@@ -53,11 +60,7 @@ function FmPageCard({
 }: {
 	fmPage: AppRouterOutputs['fm']['byWorkspace']['fmPages'][0];
 }) {
-	const {
-		setShowUpdateFmPageModal,
-		setShowArchiveFmPageModal,
-		setShowDeleteFmPageModal,
-	} = useFmContext();
+	const { setShowUpdateModal, setShowArchiveModal, setShowDeleteModal } = useFmContext();
 
 	const { coverArt } = fmPage;
 
@@ -68,9 +71,9 @@ function FmPageCard({
 			id={fmPage.id}
 			key={fmPage.id}
 			textValue={fmPage.title}
-			setShowUpdateModal={setShowUpdateFmPageModal}
-			setShowArchiveModal={setShowArchiveFmPageModal}
-			setShowDeleteModal={setShowDeleteFmPageModal}
+			setShowUpdateModal={setShowUpdateModal}
+			setShowArchiveModal={setShowArchiveModal}
+			setShowDeleteModal={setShowDeleteModal}
 			img={{ ...coverArt, alt: `${fmPage.title} cover art` }}
 			title={fmPage.title}
 			subtitle={`${fmPage.clicks} clicks`}

--- a/apps/app/src/app/[handle]/fm/_components/archive-or-delete-fm-modal.tsx
+++ b/apps/app/src/app/[handle]/fm/_components/archive-or-delete-fm-modal.tsx
@@ -8,20 +8,19 @@ import { useFmContext } from '~/app/[handle]/fm/_components/fm-context';
 
 export function ArchiveOrDeleteFmModal({ mode }: { mode: 'archive' | 'delete' }) {
 	const {
-		fmPageSelection,
-		lastSelectedFmPage,
-		showArchiveFmPageModal,
-		showDeleteFmPageModal,
-		setShowArchiveFmPageModal,
-		setShowDeleteFmPageModal,
+		selection,
+		lastSelectedItem,
+		showArchiveModal,
+		showDeleteModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
 	} = useFmContext();
 
 	const apiUtils = api.useUtils();
 
-	const showModal = mode === 'archive' ? showArchiveFmPageModal : showDeleteFmPageModal;
+	const showModal = mode === 'archive' ? showArchiveModal : showDeleteModal;
 
-	const setShowModal =
-		mode === 'archive' ? setShowArchiveFmPageModal : setShowDeleteFmPageModal;
+	const setShowModal = mode === 'archive' ? setShowArchiveModal : setShowDeleteModal;
 
 	const onSuccess = useCallback(async () => {
 		await apiUtils.fm.invalidate();
@@ -35,13 +34,13 @@ export function ArchiveOrDeleteFmModal({ mode }: { mode: 'archive' | 'delete' })
 		{ onSuccess },
 	);
 
-	if (!lastSelectedFmPage) return null;
+	if (!lastSelectedItem) return null;
 
 	return (
 		<ArchiveOrDeleteModal
 			mode={mode}
-			selection={fmPageSelection}
-			lastSelected={{ ...lastSelectedFmPage, name: lastSelectedFmPage.title }}
+			selection={selection}
+			lastSelected={{ ...lastSelectedItem, name: lastSelectedItem.title }}
 			showModal={showModal}
 			setShowModal={setShowModal}
 			archiveItems={archiveFmPages}

--- a/apps/app/src/app/[handle]/fm/_components/create-fm-page-button.tsx
+++ b/apps/app/src/app/[handle]/fm/_components/create-fm-page-button.tsx
@@ -5,12 +5,12 @@ import { Button } from '@barely/ui/elements/button';
 import { useFmContext } from '~/app/[handle]/fm/_components/fm-context';
 
 export function CreateFmPageButton() {
-	const { setShowCreateFmPageModal } = useFmContext();
+	const { setShowCreateModal } = useFmContext();
 
 	return (
 		<Button
 			onClick={() => {
-				setShowCreateFmPageModal(true);
+				setShowCreateModal(true);
 			}}
 			className='space-x-3'
 		>

--- a/apps/app/src/app/[handle]/fm/_components/create-or-update-fm-modal.tsx
+++ b/apps/app/src/app/[handle]/fm/_components/create-or-update-fm-modal.tsx
@@ -29,11 +29,11 @@ export function CreateOrUpdateFmModal({ mode }: { mode: 'create' | 'update' }) {
 
 	/* fm context */
 	const {
-		lastSelectedFmPage: selectedFmPage,
-		showCreateFmPageModal,
-		showUpdateFmPageModal,
-		setShowCreateFmPageModal,
-		setShowUpdateFmPageModal,
+		lastSelectedItem: selectedFmPage,
+		showCreateModal,
+		showUpdateModal,
+		setShowCreateModal,
+		setShowUpdateModal,
 		focusGridList,
 	} = useFmContext();
 
@@ -103,9 +103,8 @@ export function CreateOrUpdateFmModal({ mode }: { mode: 'create' | 'update' }) {
 	} = artworkUploadState;
 
 	/* modal */
-	const showFmModal = mode === 'create' ? showCreateFmPageModal : showUpdateFmPageModal;
-	const setShowFmModal =
-		mode === 'create' ? setShowCreateFmPageModal : setShowUpdateFmPageModal;
+	const showFmModal = mode === 'create' ? showCreateModal : showUpdateModal;
+	const setShowFmModal = mode === 'create' ? setShowCreateModal : setShowUpdateModal;
 
 	const handleCloseModal = useCallback(async () => {
 		focusGridList();

--- a/apps/app/src/app/[handle]/fm/_components/fm-hotkeys.tsx
+++ b/apps/app/src/app/[handle]/fm/_components/fm-hotkeys.tsx
@@ -6,19 +6,19 @@ import { useFmContext } from '~/app/[handle]/fm/_components/fm-context';
 
 export function FmHotkeys() {
 	const {
-		fmPageSelection,
-		setShowArchiveFmPageModal,
-		setShowDeleteFmPageModal,
-		setShowCreateFmPageModal,
-		setShowUpdateFmPageModal,
+		selection,
+		setShowArchiveModal,
+		setShowDeleteModal,
+		setShowCreateModal,
+		setShowUpdateModal,
 	} = useFmContext();
 
 	useModalHotKeys({
-		setShowCreateModal: setShowCreateFmPageModal,
-		setShowUpdateModal: setShowUpdateFmPageModal,
-		setShowArchiveModal: setShowArchiveFmPageModal,
-		setShowDeleteModal: setShowDeleteFmPageModal,
-		itemSelected: fmPageSelection !== 'all' && !!fmPageSelection.size,
+		setShowCreateModal,
+		setShowUpdateModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
+		itemSelected: selection !== 'all' && !!selection.size,
 	});
 	return null;
 }

--- a/apps/app/src/app/[handle]/layout.tsx
+++ b/apps/app/src/app/[handle]/layout.tsx
@@ -41,7 +41,7 @@ export default async function DashboardLayout({
 	return (
 		<WorkspaceProviders user={user} workspace={currentWorkspace}>
 			<div className='mx-auto flex  w-full flex-1 flex-row '>
-				<SidebarNav workspace={currentWorkspace} />
+				<SidebarNav />
 				<NewWorkspaceModal />
 
 				<div className='flex h-[100vh] w-full flex-col bg-accent md:pt-2'>

--- a/apps/app/src/app/[handle]/links/_components/all-links.tsx
+++ b/apps/app/src/app/[handle]/links/_components/all-links.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { cn } from '@barely/lib/utils/cn';
 import { truncate } from '@barely/lib/utils/text';
 
+import { GridListSkeleton } from '@barely/ui/components/grid-list-skeleton';
 import { NoResultsPlaceholder } from '@barely/ui/components/no-results-placeholder';
 import { Badge } from '@barely/ui/elements/badge';
 import { BlurImage } from '@barely/ui/elements/blur-image';
@@ -18,13 +19,14 @@ import { useLinkContext } from '~/app/[handle]/links/_components/link-context';
 
 export function AllLinks() {
 	const {
-		links,
-		linkSelection,
-		lastSelectedLinkId,
-		setLinkSelection,
+		items,
+		selection,
+		lastSelectedItemId,
+		setSelection,
 		gridListRef,
-		setShowUpdateLinkModal,
+		setShowUpdateModal,
 		pendingFiltersTransition,
+		isFetching,
 	} = useLinkContext();
 
 	return (
@@ -37,24 +39,29 @@ export function AllLinks() {
 				selectionMode='multiple'
 				selectionBehavior='replace'
 				// links
-				items={links.map(link => ({ ...link, key: link.id, linkKey: link.key }))}
-				selectedKeys={linkSelection}
-				setSelectedKeys={setLinkSelection}
+				items={items.map(item => ({ ...item, key: item.id, linkKey: item.key }))}
+				selectedKeys={selection}
+				setSelectedKeys={setSelection}
 				onAction={() => {
-					if (!lastSelectedLinkId) return;
-					setShowUpdateLinkModal(true);
+					if (!lastSelectedItemId) return;
+					setShowUpdateModal(true);
 				}}
 				// empty
 				renderEmptyState={() => (
-					<NoResultsPlaceholder
-						icon='link'
-						title='No links found.'
-						subtitle='Create a new link to get started.'
-						button={<CreateLinkButton />}
-					/>
+					<>
+						{isFetching ?
+							<GridListSkeleton />
+						:	<NoResultsPlaceholder
+								icon='link'
+								title='No links found.'
+								subtitle='Create a new link to get started.'
+								button={<CreateLinkButton />}
+							/>
+						}
+					</>
 				)}
 			>
-				{link => <LinkCard key={link.id} link={link} />}
+				{item => <LinkCard key={item.id} link={item} />}
 			</GridList>
 		</>
 	);
@@ -65,7 +72,7 @@ function LinkCard({
 }: {
 	link: AppRouterOutputs['link']['byWorkspace']['links'][0] & { linkKey: string };
 }) {
-	const { setShowUpdateLinkModal, setShowArchiveLinkModal, setShowDeleteLinkModal } =
+	const { setShowUpdateModal, setShowArchiveModal, setShowDeleteModal } =
 		useLinkContext();
 
 	return (
@@ -73,9 +80,9 @@ function LinkCard({
 			id={link.id}
 			key={link.id}
 			textValue={link.url}
-			setShowUpdateModal={setShowUpdateLinkModal}
-			setShowArchiveModal={setShowArchiveLinkModal}
-			setShowDeleteModal={setShowDeleteLinkModal}
+			setShowUpdateModal={setShowUpdateModal}
+			setShowArchiveModal={setShowArchiveModal}
+			setShowDeleteModal={setShowDeleteModal}
 		>
 			<div className='flex flex-grow flex-row items-center gap-4'>
 				{link.favicon ?

--- a/apps/app/src/app/[handle]/links/_components/archive-or-delete-link-modal.tsx
+++ b/apps/app/src/app/[handle]/links/_components/archive-or-delete-link-modal.tsx
@@ -8,20 +8,19 @@ import { useLinkContext } from '~/app/[handle]/links/_components/link-context';
 
 export function ArchiveOrDeleteLinkModal({ mode }: { mode: 'archive' | 'delete' }) {
 	const {
-		linkSelection,
-		lastSelectedLink,
-		showArchiveLinkModal,
-		showDeleteLinkModal,
-		setShowArchiveLinkModal,
-		setShowDeleteLinkModal,
+		selection: linkSelection,
+		lastSelectedItem: lastSelectedLink,
+		showArchiveModal,
+		showDeleteModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
 	} = useLinkContext();
 
 	const apiUtils = api.useUtils();
 
-	const showModal = mode === 'archive' ? showArchiveLinkModal : showDeleteLinkModal;
+	const showModal = mode === 'archive' ? showArchiveModal : showDeleteModal;
 
-	const setShowModal =
-		mode === 'archive' ? setShowArchiveLinkModal : setShowDeleteLinkModal;
+	const setShowModal = mode === 'archive' ? setShowArchiveModal : setShowDeleteModal;
 
 	const onSuccess = useCallback(async () => {
 		await apiUtils.link.invalidate();

--- a/apps/app/src/app/[handle]/links/_components/create-link-button.tsx
+++ b/apps/app/src/app/[handle]/links/_components/create-link-button.tsx
@@ -5,12 +5,12 @@ import { Button } from '@barely/ui/elements/button';
 import { useLinkContext } from '~/app/[handle]/links/_components/link-context';
 
 export function CreateLinkButton() {
-	const { setShowCreateLinkModal } = useLinkContext();
+	const { setShowCreateModal } = useLinkContext();
 
 	return (
 		<Button
 			onClick={() => {
-				setShowCreateLinkModal(true);
+				setShowCreateModal(true);
 			}}
 			className='space-x-3'
 		>

--- a/apps/app/src/app/[handle]/links/_components/create-or-update-link-modal.tsx
+++ b/apps/app/src/app/[handle]/links/_components/create-or-update-link-modal.tsx
@@ -37,18 +37,17 @@ export function CreateOrUpdateLinkModal(props: { mode: 'create' | 'update' }) {
 
 	/* link context */
 	const {
-		lastSelectedLink: selectedLink,
-		showCreateLinkModal,
-		setShowCreateLinkModal,
-		showUpdateLinkModal,
-		setShowUpdateLinkModal,
+		lastSelectedItem: selectedLink,
+		showCreateModal,
+		setShowCreateModal,
+		showUpdateModal,
+		setShowUpdateModal,
 		focusGridList,
 	} = useLinkContext();
 
 	/* modal state */
-	const showLinkModal = mode === 'create' ? showCreateLinkModal : showUpdateLinkModal;
-	const setShowLinkModal =
-		mode === 'create' ? setShowCreateLinkModal : setShowUpdateLinkModal;
+	const showLinkModal = mode === 'create' ? showCreateModal : showUpdateModal;
+	const setShowLinkModal = mode === 'create' ? setShowCreateModal : setShowUpdateModal;
 
 	/* api */
 	const apiUtils = api.useUtils();

--- a/apps/app/src/app/[handle]/links/_components/link-hotkeys.tsx
+++ b/apps/app/src/app/[handle]/links/_components/link-hotkeys.tsx
@@ -6,19 +6,19 @@ import { useLinkContext } from '~/app/[handle]/links/_components/link-context';
 
 export function LinkHotkeys() {
 	const {
-		linkSelection,
-		setShowCreateLinkModal,
-		setShowUpdateLinkModal,
-		setShowArchiveLinkModal,
-		setShowDeleteLinkModal,
+		selection,
+		setShowCreateModal,
+		setShowUpdateModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
 	} = useLinkContext();
 
 	useModalHotKeys({
-		setShowCreateModal: setShowCreateLinkModal,
-		setShowUpdateModal: setShowUpdateLinkModal,
-		setShowArchiveModal: setShowArchiveLinkModal,
-		setShowDeleteModal: setShowDeleteLinkModal,
-		itemSelected: linkSelection !== 'all' && !!linkSelection.size,
+		setShowCreateModal: setShowCreateModal,
+		setShowUpdateModal: setShowUpdateModal,
+		setShowArchiveModal: setShowArchiveModal,
+		setShowDeleteModal: setShowDeleteModal,
+		itemSelected: selection !== 'all' && !!selection.size,
 	});
 
 	return null;

--- a/apps/app/src/app/[handle]/media/_components/all-media.tsx
+++ b/apps/app/src/app/[handle]/media/_components/all-media.tsx
@@ -3,6 +3,7 @@
 import type { FileRecord } from '@barely/lib/server/routes/file/file.schema';
 import { nFormatter } from '@barely/lib/utils/number';
 
+import { GridListSkeleton } from '@barely/ui/components/grid-list-skeleton';
 import { NoResultsPlaceholder } from '@barely/ui/components/no-results-placeholder';
 import { GridItemCheckbox, GridList, GridListItem } from '@barely/ui/elements/grid-list';
 import { Icon } from '@barely/ui/elements/icon';
@@ -12,7 +13,7 @@ import { Text } from '@barely/ui/elements/typography';
 import { useMediaContext } from '~/app/[handle]/media/_components/media-context';
 
 export function AllMedia() {
-	const { files, fileSelection, setFileSelection, gridListRef } = useMediaContext();
+	const { items, selection, setSelection, gridListRef, isFetching } = useMediaContext();
 
 	return (
 		<>
@@ -27,19 +28,24 @@ export function AllMedia() {
 				selectionMode='multiple'
 				selectionBehavior='toggle'
 				// files
-				items={files}
-				selectedKeys={fileSelection}
-				setSelectedKeys={setFileSelection}
+				items={items}
+				selectedKeys={selection}
+				setSelectedKeys={setSelection}
 				// empty
 				renderEmptyState={() => (
-					<NoResultsPlaceholder
-						icon='file'
-						title='No files found.'
-						subtitle='Upload a file to get started.'
-					/>
+					<>
+						{isFetching ?
+							<GridListSkeleton />
+						:	<NoResultsPlaceholder
+								icon='file'
+								title='No files found.'
+								subtitle='Upload a file to get started.'
+							/>
+						}{' '}
+					</>
 				)}
 			>
-				{file => <FileCard file={file} />}
+				{item => <FileCard file={item} />}
 			</GridList>
 		</>
 	);

--- a/apps/app/src/app/[handle]/media/_components/upload-media-button.tsx
+++ b/apps/app/src/app/[handle]/media/_components/upload-media-button.tsx
@@ -5,12 +5,12 @@ import { Button } from '@barely/ui/elements/button';
 import { useMediaContext } from '~/app/[handle]/media/_components/media-context';
 
 export function UploadMediaButton() {
-	const { setShowUploadMediaModal } = useMediaContext();
+	const { setShowCreateModal } = useMediaContext();
 
 	return (
 		<Button
 			onClick={() => {
-				setShowUploadMediaModal(true);
+				setShowCreateModal(true);
 			}}
 			className='space-x-3'
 		>

--- a/apps/app/src/app/[handle]/media/_components/upload-media-modal.tsx
+++ b/apps/app/src/app/[handle]/media/_components/upload-media-modal.tsx
@@ -16,7 +16,7 @@ const mediaUploadQueueAtom = atom<UploadQueueItem[]>([]);
 export function UploadMediaModal() {
 	const apiUtils = api.useUtils();
 
-	const { showUploadMediaModal, setShowUploadMediaModal } = useMediaContext();
+	const { showCreateModal, setShowCreateModal } = useMediaContext();
 
 	const mediaUploadState = useUpload({
 		uploadQueueAtom: mediaUploadQueueAtom,
@@ -24,7 +24,7 @@ export function UploadMediaModal() {
 		maxFiles: 50,
 		onUploadComplete: async () => {
 			await apiUtils.file.invalidate();
-			setShowUploadMediaModal(false);
+			setShowCreateModal(false);
 		},
 	});
 
@@ -32,8 +32,8 @@ export function UploadMediaModal() {
 
 	return (
 		<Modal
-			showModal={showUploadMediaModal}
-			setShowModal={setShowUploadMediaModal}
+			showModal={showCreateModal}
+			setShowModal={setShowCreateModal}
 			className='w-full'
 		>
 			<ModalHeader title='Upload Media' icon='media' />

--- a/apps/app/src/app/[handle]/mixtapes/_components/all-mixtapes.tsx
+++ b/apps/app/src/app/[handle]/mixtapes/_components/all-mixtapes.tsx
@@ -2,6 +2,7 @@
 
 import type { AppRouterOutputs } from '@barely/lib/server/api/router';
 
+import { GridListSkeleton } from '@barely/ui/components/grid-list-skeleton';
 import { NoResultsPlaceholder } from '@barely/ui/components/no-results-placeholder';
 import { GridList, GridListCard } from '@barely/ui/elements/grid-list';
 
@@ -10,12 +11,13 @@ import { useMixtapesContext } from '~/app/[handle]/mixtapes/_components/mixtape-
 
 export function AllMixtapes() {
 	const {
-		mixtapes,
-		mixtapeSelection,
-		lastSelectedMixtapeId,
-		setMixtapeSelection,
+		items,
+		selection,
+		lastSelectedItemId,
+		setSelection,
 		gridListRef,
-		setShowUpdateMixtapeModal,
+		setShowUpdateModal,
+		isFetching,
 	} = useMixtapesContext();
 
 	return (
@@ -27,22 +29,27 @@ export function AllMixtapes() {
 				selectionMode='multiple'
 				selectionBehavior='replace'
 				onAction={() => {
-					if (!lastSelectedMixtapeId) return;
-					setShowUpdateMixtapeModal(true);
+					if (!lastSelectedItemId) return;
+					setShowUpdateModal(true);
 				}}
-				items={mixtapes}
-				selectedKeys={mixtapeSelection}
-				setSelectedKeys={setMixtapeSelection}
+				items={items}
+				selectedKeys={selection}
+				setSelectedKeys={setSelection}
 				renderEmptyState={() => (
-					<NoResultsPlaceholder
-						icon='mixtape'
-						title='No Mixtapes'
-						subtitle='Create a new mixtape to get started.'
-						button={<CreateMixtapeButton />}
-					/>
+					<>
+						{isFetching ?
+							<GridListSkeleton />
+						:	<NoResultsPlaceholder
+								icon='mixtape'
+								title='No Mixtapes'
+								subtitle='Create a new mixtape to get started.'
+								button={<CreateMixtapeButton />}
+							/>
+						}
+					</>
 				)}
 			>
-				{mixtape => <MixtapeCard mixtape={mixtape} />}
+				{item => <MixtapeCard mixtape={item} />}
 			</GridList>
 		</>
 	);
@@ -53,20 +60,17 @@ function MixtapeCard({
 }: {
 	mixtape: AppRouterOutputs['mixtape']['byWorkspace']['mixtapes'][0];
 }) {
-	const {
-		setShowUpdateMixtapeModal,
-		setShowArchiveMixtapeModal,
-		setShowDeleteMixtapeModal,
-	} = useMixtapesContext();
+	const { setShowUpdateModal, setShowArchiveModal, setShowDeleteModal } =
+		useMixtapesContext();
 
 	return (
 		<GridListCard
 			id={mixtape.id}
 			key={mixtape.id}
 			textValue={mixtape.name}
-			setShowUpdateModal={setShowUpdateMixtapeModal}
-			setShowArchiveModal={setShowArchiveMixtapeModal}
-			setShowDeleteModal={setShowDeleteMixtapeModal}
+			setShowUpdateModal={setShowUpdateModal}
+			setShowArchiveModal={setShowArchiveModal}
+			setShowDeleteModal={setShowDeleteModal}
 		>
 			{mixtape.name}
 		</GridListCard>

--- a/apps/app/src/app/[handle]/mixtapes/_components/archive-or-delete-mixtape-modal.tsx
+++ b/apps/app/src/app/[handle]/mixtapes/_components/archive-or-delete-mixtape-modal.tsx
@@ -8,20 +8,19 @@ import { useMixtapesContext } from '~/app/[handle]/mixtapes/_components/mixtape-
 
 export function ArchiveOrDeleteMixtapeModal({ mode }: { mode: 'archive' | 'delete' }) {
 	const {
-		mixtapeSelection,
-		lastSelectedMixtape,
-		showArchiveMixtapeModal,
-		showDeleteMixtapeModal,
-		setShowArchiveMixtapeModal,
-		setShowDeleteMixtapeModal,
+		selection,
+		lastSelectedItem,
+		showArchiveModal,
+		showDeleteModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
 	} = useMixtapesContext();
 
 	const apiUtils = api.useUtils();
 
-	const showModal = mode === 'archive' ? showArchiveMixtapeModal : showDeleteMixtapeModal;
+	const showModal = mode === 'archive' ? showArchiveModal : showDeleteModal;
 
-	const setShowModal =
-		mode === 'archive' ? setShowArchiveMixtapeModal : setShowDeleteMixtapeModal;
+	const setShowModal = mode === 'archive' ? setShowArchiveModal : setShowDeleteModal;
 
 	const onSuccess = useCallback(async () => {
 		await apiUtils.mixtape.invalidate();
@@ -34,13 +33,13 @@ export function ArchiveOrDeleteMixtapeModal({ mode }: { mode: 'archive' | 'delet
 	const { mutate: deleteMixtapes, isPending: isPendingDelete } =
 		api.mixtape.delete.useMutation({ onSuccess });
 
-	if (!lastSelectedMixtape) return null;
+	if (!lastSelectedItem) return null;
 
 	return (
 		<ArchiveOrDeleteModal
 			mode={mode}
-			selection={mixtapeSelection}
-			lastSelected={lastSelectedMixtape}
+			selection={selection}
+			lastSelected={lastSelectedItem}
 			showModal={showModal}
 			setShowModal={setShowModal}
 			archiveItems={archiveMixtapes}

--- a/apps/app/src/app/[handle]/mixtapes/_components/create-mixtape-button.tsx
+++ b/apps/app/src/app/[handle]/mixtapes/_components/create-mixtape-button.tsx
@@ -5,12 +5,12 @@ import { Button } from '@barely/ui/elements/button';
 import { useMixtapesContext } from '~/app/[handle]/mixtapes/_components/mixtape-context';
 
 export function CreateMixtapeButton() {
-	const { setShowCreateMixtapeModal } = useMixtapesContext();
+	const { setShowCreateModal } = useMixtapesContext();
 
 	return (
 		<Button
 			onClick={() => {
-				setShowCreateMixtapeModal(true);
+				setShowCreateModal(true);
 			}}
 			className='space-x-3'
 		>

--- a/apps/app/src/app/[handle]/mixtapes/_components/mixtape-hotkeys.tsx
+++ b/apps/app/src/app/[handle]/mixtapes/_components/mixtape-hotkeys.tsx
@@ -6,19 +6,19 @@ import { useMixtapesContext } from '~/app/[handle]/mixtapes/_components/mixtape-
 
 export function MixtapeHotkeys() {
 	const {
-		mixtapeSelection,
-		setShowArchiveMixtapeModal,
-		setShowDeleteMixtapeModal,
-		setShowCreateMixtapeModal,
-		setShowUpdateMixtapeModal,
+		selection,
+		setShowArchiveModal,
+		setShowDeleteModal,
+		setShowCreateModal,
+		setShowUpdateModal,
 	} = useMixtapesContext();
 
 	useModalHotKeys({
-		setShowCreateModal: setShowCreateMixtapeModal,
-		setShowUpdateModal: setShowUpdateMixtapeModal,
-		setShowArchiveModal: setShowArchiveMixtapeModal,
-		setShowDeleteModal: setShowDeleteMixtapeModal,
-		itemSelected: mixtapeSelection !== 'all' && !!mixtapeSelection.size,
+		setShowCreateModal,
+		setShowUpdateModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
+		itemSelected: selection !== 'all' && !!selection.size,
 	});
 
 	return null;

--- a/apps/app/src/app/[handle]/orders/_components/all-cart-orders.tsx
+++ b/apps/app/src/app/[handle]/orders/_components/all-cart-orders.tsx
@@ -9,6 +9,7 @@ import { getTrackingLink } from '@barely/lib/server/shipping/shipping.utils';
 import { formatCentsToDollars } from '@barely/lib/utils/currency';
 import { numToPaddedString } from '@barely/lib/utils/number';
 
+import { GridListSkeleton } from '@barely/ui/components/grid-list-skeleton';
 import { NoResultsPlaceholder } from '@barely/ui/components/no-results-placeholder';
 import { Badge } from '@barely/ui/elements/badge';
 import { Button } from '@barely/ui/elements/button';
@@ -19,7 +20,7 @@ import { Text } from '@barely/ui/elements/typography';
 import { useCartOrderContext } from '~/app/[handle]/orders/_components/cart-order-context';
 
 export function AllCartOrders() {
-	const { cartOrders, cartOrderSelection, setCartOrderSelection, gridListRef } =
+	const { items, selection, setSelection, gridListRef, isFetching } =
 		useCartOrderContext();
 
 	return (
@@ -30,17 +31,21 @@ export function AllCartOrders() {
 				className='flex flex-col gap-4'
 				selectionMode='multiple'
 				selectionBehavior='replace'
-				items={cartOrders}
-				selectedKeys={cartOrderSelection}
-				setSelectedKeys={setCartOrderSelection}
+				items={items}
+				selectedKeys={selection}
+				setSelectedKeys={setSelection}
 				onAction={() => {
-					if (!cartOrderSelection) return;
+					if (!selection) return;
 				}}
 				renderEmptyState={() => (
-					<NoResultsPlaceholder icon='order' title='No orders found.' />
+					<>
+						{isFetching ?
+							<GridListSkeleton />
+						:	<NoResultsPlaceholder icon='order' title='No orders found.' />}
+					</>
 				)}
 			>
-				{order => <CartOrderCard cartOrder={order} />}
+				{item => <CartOrderCard cartOrder={item} />}
 			</GridList>
 			<LoadMoreButton />
 		</div>
@@ -76,8 +81,8 @@ function CartOrderCard({
 	const {
 		setShowMarkAsFulfilledModal,
 		setShowCancelCartOrderModal,
-		setCartOrderSelection,
-		cartOrderSelection,
+		setSelection,
+		selection,
 	} = useCartOrderContext();
 
 	const { handle } = useWorkspace();
@@ -87,7 +92,7 @@ function CartOrderCard({
 		icon: 'fulfillment',
 		shortcut: ['f'],
 		action: () => {
-			setCartOrderSelection(new Set([cartOrder.id]));
+			setSelection(new Set([cartOrder.id]));
 			setShowMarkAsFulfilledModal(true);
 		},
 	};
@@ -97,7 +102,7 @@ function CartOrderCard({
 		icon: 'x',
 		shortcut: ['x'],
 		action: () => {
-			setCartOrderSelection(new Set([cartOrder.id]));
+			setSelection(new Set([cartOrder.id]));
 			setShowCancelCartOrderModal(true);
 		},
 	};
@@ -125,10 +130,10 @@ function CartOrderCard({
 			textValue={cartOrder.id}
 			commandItems={commandItems}
 			actionOnCommandMenuOpen={() => {
-				if (cartOrderSelection === 'all' || cartOrderSelection.has(cartOrder.id)) {
+				if (selection === 'all' || selection.has(cartOrder.id)) {
 					return;
 				}
-				setCartOrderSelection(new Set([cartOrder.id]));
+				setSelection(new Set([cartOrder.id]));
 			}}
 		>
 			<div className='flex w-full flex-col gap-4'>

--- a/apps/app/src/app/[handle]/orders/_components/cancel-cart-order-modal.tsx
+++ b/apps/app/src/app/[handle]/orders/_components/cancel-cart-order-modal.tsx
@@ -17,7 +17,7 @@ export function CancelCartOrderModal() {
 
 	// cart order context
 	const {
-		lastSelectedCartOrder: selectedCartOrder,
+		lastSelectedItem: selectedCartOrder,
 		showCancelCartOrderModal,
 		setShowCancelCartOrderModal,
 		focusGridList,

--- a/apps/app/src/app/[handle]/orders/_components/cart-order-context.tsx
+++ b/apps/app/src/app/[handle]/orders/_components/cart-order-context.tsx
@@ -2,12 +2,6 @@
 
 import type { AppRouterOutputs } from '@barely/lib/server/api/react';
 import type { cartOrderFilterParamsSchema } from '@barely/lib/server/routes/cart-order/cart-order.schema';
-import type {
-	FetchNextPageOptions,
-	// 	InfiniteData,
-	// 	InfiniteQueryObserverResult,
-	// 	UseInfiniteQueryResult,
-} from '@tanstack/react-query';
 import type { Selection } from 'react-aria-components';
 import type { z } from 'zod';
 import { createContext, use, useCallback, useContext, useRef, useState } from 'react';
@@ -16,34 +10,50 @@ import { useWorkspace } from '@barely/lib/hooks/use-workspace';
 import { api } from '@barely/lib/server/api/react';
 import { cartOrderSearchParamsSchema } from '@barely/lib/server/routes/cart-order/cart-order.schema';
 
-interface CartOrderContext {
-	cartOrders: AppRouterOutputs['cartOrder']['byWorkspace']['cartOrders'];
-	cartOrderSelection: Selection;
-	lastSelectedCartOrderId: string | undefined;
-	lastSelectedCartOrder:
-		| AppRouterOutputs['cartOrder']['byWorkspace']['cartOrders'][0]
-		| undefined;
-	setCartOrderSelection: (selection: Selection) => void;
-	gridListRef: React.RefObject<HTMLDivElement>;
-	focusGridList: () => void;
+import type { InfiniteItemsContext } from '~/app/[handle]/_types/all-items-context';
+
+// interface CartOrderContext {
+// 	cartOrders: AppRouterOutputs['cartOrder']['byWorkspace']['cartOrders'];
+// 	cartOrderSelection: Selection;
+// 	lastSelectedCartOrderId: string | undefined;
+// 	lastSelectedCartOrder:
+// 		| AppRouterOutputs['cartOrder']['byWorkspace']['cartOrders'][0]
+// 		| undefined;
+// 	setCartOrderSelection: (selection: Selection) => void;
+// 	gridListRef: React.RefObject<HTMLDivElement>;
+// 	focusGridList: () => void;
+// 	showMarkAsFulfilledModal: boolean;
+// 	setShowMarkAsFulfilledModal: (show: boolean) => void;
+// 	showCancelCartOrderModal: boolean;
+// 	setShowCancelCartOrderModal: (show: boolean) => void;
+// 	//infinite
+// 	queryIsPending: boolean;
+// 	hasNextPage: boolean;
+// 	fetchNextPage: (options?: FetchNextPageOptions) => void | Promise<void>;
+// 	isFetchingNextPage: boolean;
+// 	// filters
+// 	filters: z.infer<typeof cartOrderFilterParamsSchema>;
+// 	pendingFiltersTransition: boolean;
+// 	setSearch: (search: string) => void;
+// 	toggleArchived: () => void;
+// 	toggleFulfilled: () => void;
+// 	clearAllFilters: () => void;
+// 	togglePreorders: () => void;
+// 	toggleCanceled: () => void;
+// }
+
+type CartOrderContext = InfiniteItemsContext<
+	AppRouterOutputs['cartOrder']['byWorkspace']['cartOrders'][0],
+	z.infer<typeof cartOrderFilterParamsSchema>
+> & {
 	showMarkAsFulfilledModal: boolean;
 	setShowMarkAsFulfilledModal: (show: boolean) => void;
 	showCancelCartOrderModal: boolean;
 	setShowCancelCartOrderModal: (show: boolean) => void;
-	//infinite
-	hasNextPage: boolean;
-	fetchNextPage: (options?: FetchNextPageOptions) => void | Promise<void>;
-	isFetchingNextPage: boolean;
-	// filters
-	filters: z.infer<typeof cartOrderFilterParamsSchema>;
-	pendingFiltersTransition: boolean;
-	setSearch: (search: string) => void;
-	toggleArchived: () => void;
 	toggleFulfilled: () => void;
-	clearAllFilters: () => void;
 	togglePreorders: () => void;
 	toggleCanceled: () => void;
-}
+};
 
 const CartOrderContext = createContext<CartOrderContext | undefined>(undefined);
 
@@ -56,6 +66,10 @@ export function CartOrderContextProvider({
 }) {
 	const [showMarkAsFulfilledModal, setShowMarkAsFulfilledModal] = useState(false);
 	const [showCancelCartOrderModal, setShowCancelCartOrderModal] = useState(false);
+
+	// const apiUtils = api.useUtils();
+
+	// apiUtils.
 
 	const { handle } = useWorkspace();
 
@@ -76,6 +90,9 @@ export function CartOrderContextProvider({
 		hasNextPage,
 		fetchNextPage,
 		isFetchingNextPage,
+		isFetching,
+		isRefetching,
+		isPending,
 	} = api.cartOrder.byWorkspace.useInfiniteQuery(
 		{
 			handle,
@@ -168,14 +185,22 @@ export function CartOrderContextProvider({
 	);
 
 	const contextValue = {
-		cartOrders,
-		cartOrderSelection,
-		lastSelectedCartOrderId,
-		lastSelectedCartOrder,
-		setCartOrderSelection,
+		items: cartOrders,
+		selection: cartOrderSelection,
+		lastSelectedItemId: lastSelectedCartOrderId,
+		lastSelectedItem: lastSelectedCartOrder,
+		setSelection: setCartOrderSelection,
 		gridListRef,
 		focusGridList: () => gridListRef.current?.focus(),
 		// modals
+		showCreateModal: false,
+		setShowCreateModal: () => void {},
+		showUpdateModal: false,
+		setShowUpdateModal: () => void {},
+		showDeleteModal: false,
+		setShowDeleteModal: () => void {},
+		showArchiveModal: false,
+		setShowArchiveModal: () => void {},
 		showMarkAsFulfilledModal,
 		setShowMarkAsFulfilledModal,
 		showCancelCartOrderModal,
@@ -193,6 +218,9 @@ export function CartOrderContextProvider({
 		hasNextPage,
 		fetchNextPage: () => void fetchNextPage(),
 		isFetchingNextPage,
+		isFetching,
+		isRefetching,
+		isPending,
 	} satisfies CartOrderContext;
 
 	return (

--- a/apps/app/src/app/[handle]/orders/_components/cart-order-hotkeys.tsx
+++ b/apps/app/src/app/[handle]/orders/_components/cart-order-hotkeys.tsx
@@ -7,35 +7,32 @@ import { useCartOrderContext } from '~/app/[handle]/orders/_components/cart-orde
 
 export function CartOrderHotkeys() {
 	const {
-		cartOrderSelection,
+		selection,
 		setShowMarkAsFulfilledModal,
 		setShowCancelCartOrderModal,
-		lastSelectedCartOrder,
+		lastSelectedItem,
 	} = useCartOrderContext();
 
 	const fulfillAction = useCallback(() => {
-		if (
-			!lastSelectedCartOrder ||
-			lastSelectedCartOrder.fulfillmentStatus === 'fulfilled'
-		) {
+		if (!lastSelectedItem || lastSelectedItem.fulfillmentStatus === 'fulfilled') {
 			return;
 		}
 		setShowMarkAsFulfilledModal(true);
-	}, [lastSelectedCartOrder, setShowMarkAsFulfilledModal]);
+	}, [lastSelectedItem, setShowMarkAsFulfilledModal]);
 
 	const cancelAction = useCallback(() => {
 		if (
-			!lastSelectedCartOrder ||
-			!!lastSelectedCartOrder.canceledAt ||
-			lastSelectedCartOrder.fulfillmentStatus !== 'pending'
+			!lastSelectedItem ||
+			!!lastSelectedItem.canceledAt ||
+			lastSelectedItem.fulfillmentStatus !== 'pending'
 		) {
 			return;
 		}
 		setShowCancelCartOrderModal(true);
-	}, [lastSelectedCartOrder, setShowCancelCartOrderModal]);
+	}, [lastSelectedItem, setShowCancelCartOrderModal]);
 
 	useModalHotKeys({
-		itemSelected: cartOrderSelection !== 'all' && !!cartOrderSelection.size,
+		itemSelected: selection !== 'all' && !!selection.size,
 		customHotkeys: [
 			{
 				condition: e => e.key === 'f' && !e.metaKey && !e.ctrlKey && !e.shiftKey,

--- a/apps/app/src/app/[handle]/orders/_components/mark-cart-order-fulfilled-modal.tsx
+++ b/apps/app/src/app/[handle]/orders/_components/mark-cart-order-fulfilled-modal.tsx
@@ -40,7 +40,7 @@ export function MarkCartOrderFulfilledModal() {
 
 	/* cart order context */
 	const {
-		lastSelectedCartOrder: selectedCartOrder,
+		lastSelectedItem: selectedCartOrder,
 		showMarkAsFulfilledModal,
 		setShowMarkAsFulfilledModal,
 		focusGridList,

--- a/apps/app/src/app/[handle]/pages/_components/all-landing-pages.tsx
+++ b/apps/app/src/app/[handle]/pages/_components/all-landing-pages.tsx
@@ -4,6 +4,7 @@ import type { LandingPage } from '@barely/lib/server/routes/landing-page/landing
 import { formatCentsToDollars } from '@barely/lib/utils/currency';
 import { getAbsoluteUrl } from '@barely/lib/utils/url';
 
+import { GridListSkeleton } from '@barely/ui/components/grid-list-skeleton';
 import { NoResultsPlaceholder } from '@barely/ui/components/no-results-placeholder';
 import { GridList, GridListCard } from '@barely/ui/elements/grid-list';
 
@@ -11,13 +12,8 @@ import { CreateLandingPageButton } from '~/app/[handle]/pages/_components/create
 import { useLandingPageContext } from '~/app/[handle]/pages/_components/landing-page-context';
 
 export function AllLandingPages() {
-	const {
-		landingPages,
-		landingPageSelection,
-		setLandingPageSelection,
-		gridListRef,
-		setShowUpdateLandingPageModal,
-	} = useLandingPageContext();
+	const { items, selection, setSelection, gridListRef, setShowUpdateModal, isFetching } =
+		useLandingPageContext();
 
 	return (
 		<>
@@ -29,24 +25,26 @@ export function AllLandingPages() {
 				selectionMode='multiple'
 				selectionBehavior='replace'
 				// landingPages
-				items={landingPages}
-				selectedKeys={landingPageSelection}
-				setSelectedKeys={setLandingPageSelection}
+				items={items}
+				selectedKeys={selection}
+				setSelectedKeys={setSelection}
 				onAction={() => {
-					if (!landingPageSelection) return;
-					setShowUpdateLandingPageModal(true);
+					if (!selection) return;
+					setShowUpdateModal(true);
 				}}
 				// empty
-				renderEmptyState={() => (
-					<NoResultsPlaceholder
-						icon='landingPage'
-						title='No landing pages found.'
-						subtitle='Create your first landing page to get started.'
-						button={<CreateLandingPageButton />}
-					/>
-				)}
+				renderEmptyState={() =>
+					isFetching ?
+						<GridListSkeleton />
+					:	<NoResultsPlaceholder
+							icon='landingPage'
+							title='No landing pages found.'
+							subtitle='Create your first landing page to get started.'
+							button={<CreateLandingPageButton />}
+						/>
+				}
 			>
-				{landingPage => <LandingPageCard landingPage={landingPage} />}
+				{item => <LandingPageCard landingPage={item} />}
 			</GridList>
 			{/* <Button look='success'>success</Button> */}
 		</>
@@ -54,11 +52,8 @@ export function AllLandingPages() {
 }
 
 function LandingPageCard({ landingPage }: { landingPage: LandingPage }) {
-	const {
-		setShowUpdateLandingPageModal,
-		setShowArchiveLandingPageModal,
-		setShowDeleteLandingPageModal,
-	} = useLandingPageContext();
+	const { setShowUpdateModal, setShowArchiveModal, setShowDeleteModal } =
+		useLandingPageContext();
 
 	const href = getAbsoluteUrl('page', `${landingPage.handle}/${landingPage.key}`);
 
@@ -67,9 +62,9 @@ function LandingPageCard({ landingPage }: { landingPage: LandingPage }) {
 			id={landingPage.id}
 			key={landingPage.id}
 			textValue={landingPage.name}
-			setShowUpdateModal={setShowUpdateLandingPageModal}
-			setShowArchiveModal={setShowArchiveLandingPageModal}
-			setShowDeleteModal={setShowDeleteLandingPageModal}
+			setShowUpdateModal={setShowUpdateModal}
+			setShowArchiveModal={setShowArchiveModal}
+			setShowDeleteModal={setShowDeleteModal}
 			title={landingPage.name}
 			subtitle={landingPage.key}
 			quickActions={{

--- a/apps/app/src/app/[handle]/pages/_components/archive-or-delete-landing-page-modal.tsx
+++ b/apps/app/src/app/[handle]/pages/_components/archive-or-delete-landing-page-modal.tsx
@@ -12,21 +12,19 @@ export function ArchiveOrDeleteLandingPageModal({
 	mode: 'archive' | 'delete';
 }) {
 	const {
-		landingPageSelection,
-		lastSelectedLandingPage,
-		showArchiveLandingPageModal,
-		showDeleteLandingPageModal,
-		setShowArchiveLandingPageModal,
-		setShowDeleteLandingPageModal,
+		selection,
+		lastSelectedItem,
+		showArchiveModal,
+		showDeleteModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
 	} = useLandingPageContext();
 
 	const apiUtils = api.useUtils();
 
-	const showModal =
-		mode === 'archive' ? showArchiveLandingPageModal : showDeleteLandingPageModal;
+	const showModal = mode === 'archive' ? showArchiveModal : showDeleteModal;
 
-	const setShowModal =
-		mode === 'archive' ? setShowArchiveLandingPageModal : setShowDeleteLandingPageModal;
+	const setShowModal = mode === 'archive' ? setShowArchiveModal : setShowDeleteModal;
 
 	const onSuccess = useCallback(async () => {
 		await apiUtils.landingPage.invalidate();
@@ -39,13 +37,13 @@ export function ArchiveOrDeleteLandingPageModal({
 	const { mutate: deleteLandingPages, isPending: isPendingDelete } =
 		api.landingPage.delete.useMutation({ onSuccess });
 
-	if (!lastSelectedLandingPage) return null;
+	if (!lastSelectedItem) return null;
 
 	return (
 		<ArchiveOrDeleteModal
 			mode={mode}
-			selection={landingPageSelection}
-			lastSelected={lastSelectedLandingPage}
+			selection={selection}
+			lastSelected={lastSelectedItem}
 			showModal={showModal}
 			setShowModal={setShowModal}
 			archiveItems={archiveLandingPages}

--- a/apps/app/src/app/[handle]/pages/_components/create-landing-page-button.tsx
+++ b/apps/app/src/app/[handle]/pages/_components/create-landing-page-button.tsx
@@ -5,12 +5,12 @@ import { Button } from '@barely/ui/elements/button';
 import { useLandingPageContext } from '~/app/[handle]/pages/_components/landing-page-context';
 
 export function CreateLandingPageButton() {
-	const { setShowCreateLandingPageModal } = useLandingPageContext();
+	const { setShowCreateModal } = useLandingPageContext();
 
 	return (
 		<Button
 			onClick={() => {
-				setShowCreateLandingPageModal(true);
+				setShowCreateModal(true);
 			}}
 			className='space-x-3'
 		>

--- a/apps/app/src/app/[handle]/pages/_components/create-or-update-landing-page-modal.tsx
+++ b/apps/app/src/app/[handle]/pages/_components/create-or-update-landing-page-modal.tsx
@@ -23,11 +23,11 @@ export function CreateOrUpdateLandingPageModal({ mode }: { mode: 'create' | 'upd
 
 	/* landing page context */
 	const {
-		lastSelectedLandingPage: selectedLandingPage,
-		showCreateLandingPageModal,
-		setShowCreateLandingPageModal,
-		showUpdateLandingPageModal,
-		setShowUpdateLandingPageModal,
+		lastSelectedItem: selectedLandingPage,
+		showCreateModal,
+		setShowCreateModal,
+		showUpdateModal,
+		setShowUpdateModal,
 		focusGridList,
 	} = useLandingPageContext();
 
@@ -74,10 +74,8 @@ export function CreateOrUpdateLandingPageModal({ mode }: { mode: 'create' | 'upd
 	);
 
 	/* modal */
-	const showModal =
-		mode === 'create' ? showCreateLandingPageModal : showUpdateLandingPageModal;
-	const setShowModal =
-		mode === 'create' ? setShowCreateLandingPageModal : setShowUpdateLandingPageModal;
+	const showModal = mode === 'create' ? showCreateModal : showUpdateModal;
+	const setShowModal = mode === 'create' ? setShowCreateModal : setShowUpdateModal;
 
 	const handleCloseModal = useCallback(async () => {
 		focusGridList();

--- a/apps/app/src/app/[handle]/pages/_components/landing-page-hotkeys.tsx
+++ b/apps/app/src/app/[handle]/pages/_components/landing-page-hotkeys.tsx
@@ -6,19 +6,19 @@ import { useLandingPageContext } from '~/app/[handle]/pages/_components/landing-
 
 export function LandingPageHotkeys() {
 	const {
-		landingPageSelection,
-		setShowCreateLandingPageModal,
-		setShowUpdateLandingPageModal,
-		setShowArchiveLandingPageModal,
-		setShowDeleteLandingPageModal,
+		selection,
+		setShowCreateModal,
+		setShowUpdateModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
 	} = useLandingPageContext();
 
 	useModalHotKeys({
-		setShowCreateModal: setShowCreateLandingPageModal,
-		setShowUpdateModal: setShowUpdateLandingPageModal,
-		setShowArchiveModal: setShowArchiveLandingPageModal,
-		setShowDeleteModal: setShowDeleteLandingPageModal,
-		itemSelected: landingPageSelection !== 'all' && !!landingPageSelection.size,
+		setShowCreateModal: setShowCreateModal,
+		setShowUpdateModal: setShowUpdateModal,
+		setShowArchiveModal: setShowArchiveModal,
+		setShowDeleteModal: setShowDeleteModal,
+		itemSelected: selection !== 'all' && !!selection.size,
 	});
 
 	return null;

--- a/apps/app/src/app/[handle]/products/_components/all-products.tsx
+++ b/apps/app/src/app/[handle]/products/_components/all-products.tsx
@@ -1,20 +1,16 @@
 'use client';
 
+import { GridListSkeleton } from '@barely/ui/components/grid-list-skeleton';
 import { NoResultsPlaceholder } from '@barely/ui/components/no-results-placeholder';
 import { GridList, GridListCard } from '@barely/ui/elements/grid-list';
 
-import type { ProductCtx } from '~/app/[handle]/products/_components/product-context';
+import type { ProductContext } from '~/app/[handle]/products/_components/product-context';
 import { CreateProductButton } from '~/app/[handle]/products/_components/create-product-button';
 import { useProductContext } from '~/app/[handle]/products/_components/product-context';
 
 export function AllProducts() {
-	const {
-		products,
-		productSelection,
-		setProductSelection,
-		gridListRef,
-		setShowUpdateProductModal,
-	} = useProductContext();
+	const { items, selection, setSelection, gridListRef, setShowUpdateModal, isFetching } =
+		useProductContext();
 
 	return (
 		<GridList
@@ -25,24 +21,26 @@ export function AllProducts() {
 			selectionMode='multiple'
 			selectionBehavior='replace'
 			// products
-			items={products}
-			selectedKeys={productSelection}
-			setSelectedKeys={setProductSelection}
+			items={items}
+			selectedKeys={selection}
+			setSelectedKeys={setSelection}
 			onAction={() => {
-				if (!productSelection) return;
-				setShowUpdateProductModal(true);
+				if (!selection) return;
+				setShowUpdateModal(true);
 			}}
 			// empty
-			renderEmptyState={() => (
-				<NoResultsPlaceholder
-					icon='product'
-					title='No products found.'
-					subtitle='Create a product to get started.'
-					button={<CreateProductButton />}
-				/>
-			)}
+			renderEmptyState={() =>
+				isFetching ?
+					<GridListSkeleton />
+				:	<NoResultsPlaceholder
+						icon='product'
+						title='No products found.'
+						subtitle='Create a product to get started.'
+						button={<CreateProductButton />}
+					/>
+			}
 		>
-			{product => <ProductCard product={product} />}
+			{item => <ProductCard product={item} />}
 		</GridList>
 	);
 }
@@ -50,22 +48,19 @@ export function AllProducts() {
 function ProductCard({
 	product,
 }: {
-	product: NonNullable<ProductCtx['lastSelectedProduct']>;
+	product: NonNullable<ProductContext['lastSelectedItem']>;
 }) {
-	const {
-		setShowUpdateProductModal,
-		setShowArchiveProductModal,
-		setShowDeleteProductModal,
-	} = useProductContext();
+	const { setShowUpdateModal, setShowArchiveModal, setShowDeleteModal } =
+		useProductContext();
 
 	return (
 		<GridListCard
 			id={product.id}
 			key={product.id}
 			textValue={product.name}
-			setShowUpdateModal={setShowUpdateProductModal}
-			setShowArchiveModal={setShowArchiveProductModal}
-			setShowDeleteModal={setShowDeleteProductModal}
+			setShowUpdateModal={setShowUpdateModal}
+			setShowArchiveModal={setShowArchiveModal}
+			setShowDeleteModal={setShowDeleteModal}
 			title={product.name}
 			img={{ ...product.images[0], alt: `${product.name} product image` }}
 		>

--- a/apps/app/src/app/[handle]/products/_components/archive-or-delete-product-modal.tsx
+++ b/apps/app/src/app/[handle]/products/_components/archive-or-delete-product-modal.tsx
@@ -8,20 +8,19 @@ import { useProductContext } from '~/app/[handle]/products/_components/product-c
 
 export function ArchiveOrDeleteProductModal({ mode }: { mode: 'archive' | 'delete' }) {
 	const {
-		productSelection,
-		lastSelectedProduct,
-		showArchiveProductModal,
-		showDeleteProductModal,
-		setShowArchiveProductModal,
-		setShowDeleteProductModal,
+		selection,
+		lastSelectedItem,
+		showArchiveModal,
+		showDeleteModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
 	} = useProductContext();
 
 	const apiUtils = api.useUtils();
 
-	const showModal = mode === 'archive' ? showArchiveProductModal : showDeleteProductModal;
+	const showModal = mode === 'archive' ? showArchiveModal : showDeleteModal;
 
-	const setShowModal =
-		mode === 'archive' ? setShowArchiveProductModal : setShowDeleteProductModal;
+	const setShowModal = mode === 'archive' ? setShowArchiveModal : setShowDeleteModal;
 
 	const onSuccess = useCallback(async () => {
 		await apiUtils.product.invalidate();
@@ -34,13 +33,13 @@ export function ArchiveOrDeleteProductModal({ mode }: { mode: 'archive' | 'delet
 	const { mutate: deleteProducts, isPending: isPendingDelete } =
 		api.product.delete.useMutation({ onSuccess });
 
-	if (!lastSelectedProduct) return null;
+	if (!lastSelectedItem) return null;
 
 	return (
 		<ArchiveOrDeleteModal
 			mode={mode}
-			selection={productSelection}
-			lastSelected={lastSelectedProduct}
+			selection={selection}
+			lastSelected={lastSelectedItem}
 			showModal={showModal}
 			setShowModal={setShowModal}
 			archiveItems={archiveProducts}

--- a/apps/app/src/app/[handle]/products/_components/create-or-update-product-modal.tsx
+++ b/apps/app/src/app/[handle]/products/_components/create-or-update-product-modal.tsx
@@ -49,11 +49,11 @@ export function CreateOrUpdateProductModal({ mode }: { mode: 'create' | 'update'
 
 	/* product context */
 	const {
-		lastSelectedProduct: selectedProduct,
-		showCreateProductModal,
-		setShowCreateProductModal,
-		showUpdateProductModal,
-		setShowUpdateProductModal,
+		lastSelectedItem: selectedProduct,
+		showCreateModal,
+		setShowCreateModal,
+		showUpdateModal,
+		setShowUpdateModal,
 		focusGridList,
 	} = useProductContext();
 
@@ -70,7 +70,7 @@ export function CreateOrUpdateProductModal({ mode }: { mode: 'create' | 'update'
 		},
 	});
 
-	upsertProductSchema.shape.preorderDeliveryEstimate;
+	// upsertProductSchema.shape.preorderDeliveryEstimate;
 
 	/* form */
 	const { form, onSubmit: onSubmitProduct } = useCreateOrUpdateForm({
@@ -159,9 +159,8 @@ export function CreateOrUpdateProductModal({ mode }: { mode: 'create' | 'update'
 	/* apparel sizes */
 
 	/* modal state */
-	const showModal = mode === 'create' ? showCreateProductModal : showUpdateProductModal;
-	const setShowModal =
-		mode === 'create' ? setShowCreateProductModal : setShowUpdateProductModal;
+	const showModal = mode === 'create' ? showCreateModal : showUpdateModal;
+	const setShowModal = mode === 'create' ? setShowCreateModal : setShowUpdateModal;
 
 	const handleCloseModal = useCallback(async () => {
 		reset();

--- a/apps/app/src/app/[handle]/products/_components/create-product-button.tsx
+++ b/apps/app/src/app/[handle]/products/_components/create-product-button.tsx
@@ -6,12 +6,12 @@ import { CommandShortcut } from '@barely/ui/elements/command';
 import { useProductContext } from '~/app/[handle]/products/_components/product-context';
 
 export function CreateProductButton() {
-	const { setShowCreateProductModal } = useProductContext();
+	const { setShowCreateModal } = useProductContext();
 
 	return (
 		<Button
 			onClick={() => {
-				setShowCreateProductModal(true);
+				setShowCreateModal(true);
 			}}
 			className='space-x-3'
 		>

--- a/apps/app/src/app/[handle]/products/_components/product-context.tsx
+++ b/apps/app/src/app/[handle]/products/_components/product-context.tsx
@@ -10,33 +10,39 @@ import { useWorkspace } from '@barely/lib/hooks/use-workspace';
 import { api } from '@barely/lib/server/api/react';
 import { productSearchParamsSchema } from '@barely/lib/server/routes/product/product.schema';
 
-export interface ProductCtx {
-	products: AppRouterOutputs['product']['byWorkspace']['products'];
-	productSelection: Selection;
-	lastSelectedProductId: string | undefined;
-	lastSelectedProduct:
-		| AppRouterOutputs['product']['byWorkspace']['products'][number]
-		| undefined;
-	setProductSelection: (selection: Selection) => void;
-	gridListRef: React.RefObject<HTMLDivElement>;
-	focusGridList: () => void;
-	showCreateProductModal: boolean;
-	setShowCreateProductModal: (show: boolean) => void;
-	showUpdateProductModal: boolean;
-	setShowUpdateProductModal: (show: boolean) => void;
-	showArchiveProductModal: boolean;
-	setShowArchiveProductModal: (show: boolean) => void;
-	showDeleteProductModal: boolean;
-	setShowDeleteProductModal: (show: boolean) => void;
-	// filters
-	filters: z.infer<typeof productFilterParamsSchema>;
-	pendingFiltersTransition: boolean;
-	setSearch: (search: string) => void;
-	toggleArchived: () => void;
-	clearAllFilters: () => void;
-}
+import type { InfiniteItemsContext } from '~/app/[handle]/_types/all-items-context';
 
-const ProductContext = createContext<ProductCtx | undefined>(undefined);
+// export interface ProductCtx {
+// 	products: AppRouterOutputs['product']['byWorkspace']['products'];
+// 	productSelection: Selection;
+// 	lastSelectedProductId: string | undefined;
+// 	lastSelectedProduct:
+// 		| AppRouterOutputs['product']['byWorkspace']['products'][number]
+// 		| undefined;
+// 	setProductSelection: (selection: Selection) => void;
+// 	gridListRef: React.RefObject<HTMLDivElement>;
+// 	focusGridList: () => void;
+// 	showCreateProductModal: boolean;
+// 	setShowCreateProductModal: (show: boolean) => void;
+// 	showUpdateProductModal: boolean;
+// 	setShowUpdateProductModal: (show: boolean) => void;
+// 	showArchiveProductModal: boolean;
+// 	setShowArchiveProductModal: (show: boolean) => void;
+// 	showDeleteProductModal: boolean;
+// 	setShowDeleteProductModal: (show: boolean) => void;
+// 	// filters
+// 	filters: z.infer<typeof productFilterParamsSchema>;
+// 	pendingFiltersTransition: boolean;
+// 	setSearch: (search: string) => void;
+// 	toggleArchived: () => void;
+// 	clearAllFilters: () => void;
+// }
+export type ProductContext = InfiniteItemsContext<
+	AppRouterOutputs['product']['byWorkspace']['products'][number],
+	z.infer<typeof productFilterParamsSchema>
+>;
+
+const ProductContext = createContext<ProductContext | undefined>(undefined);
 
 export function ProductContextProvider({
 	children,
@@ -45,10 +51,10 @@ export function ProductContextProvider({
 	children: React.ReactNode;
 	initialInfiniteProducts: Promise<AppRouterOutputs['product']['byWorkspace']>;
 }) {
-	const [showCreateProductModal, setShowCreateProductModal] = useState(false);
-	const [showUpdateProductModal, setShowUpdateProductModal] = useState(false);
-	const [showArchiveProductModal, setShowArchiveProductModal] = useState(false);
-	const [showDeleteProductModal, setShowDeleteProductModal] = useState(false);
+	const [showCreateModal, setShowCreateModal] = useState(false);
+	const [showUpdateModal, setShowUpdateModal] = useState(false);
+	const [showArchiveModal, setShowArchiveModal] = useState(false);
+	const [showDeleteModal, setShowDeleteModal] = useState(false);
 
 	const { handle } = useWorkspace();
 
@@ -69,7 +75,15 @@ export function ProductContextProvider({
 
 	const initialData = use(initialInfiniteProducts);
 
-	const { data: infiniteProducts } = api.product.byWorkspace.useInfiniteQuery(
+	const {
+		data: infiniteProducts,
+		hasNextPage,
+		fetchNextPage,
+		isFetchingNextPage,
+		isFetching,
+		isRefetching,
+		isPending,
+	} = api.product.byWorkspace.useInfiniteQuery(
 		{ handle, ...filters },
 		{
 			initialData: () => {
@@ -129,28 +143,35 @@ export function ProductContextProvider({
 	const gridListRef = useRef<HTMLDivElement>(null);
 
 	const contextValue = {
-		products: products,
-		productSelection,
-		lastSelectedProductId,
-		lastSelectedProduct,
-		setProductSelection,
+		items: products,
+		selection: productSelection,
+		lastSelectedItemId: lastSelectedProductId,
+		lastSelectedItem: lastSelectedProduct,
+		setSelection: setProductSelection,
 		gridListRef,
 		focusGridList: () => gridListRef.current?.focus(),
-		showCreateProductModal,
-		setShowCreateProductModal,
-		showUpdateProductModal,
-		setShowUpdateProductModal,
-		showArchiveProductModal,
-		setShowArchiveProductModal,
-		showDeleteProductModal,
-		setShowDeleteProductModal,
+		showCreateModal,
+		setShowCreateModal,
+		showUpdateModal,
+		setShowUpdateModal,
+		showArchiveModal,
+		setShowArchiveModal,
+		showDeleteModal,
+		setShowDeleteModal,
 		// filters
 		filters,
 		pendingFiltersTransition,
 		setSearch,
 		toggleArchived,
 		clearAllFilters,
-	} satisfies ProductCtx;
+		// infinite
+		hasNextPage,
+		fetchNextPage: () => void fetchNextPage(),
+		isFetchingNextPage,
+		isFetching,
+		isRefetching,
+		isPending,
+	} satisfies ProductContext;
 
 	return (
 		<ProductContext.Provider value={contextValue}>{children}</ProductContext.Provider>

--- a/apps/app/src/app/[handle]/products/_components/product-hotkeys.tsx
+++ b/apps/app/src/app/[handle]/products/_components/product-hotkeys.tsx
@@ -6,19 +6,19 @@ import { useProductContext } from '~/app/[handle]/products/_components/product-c
 
 export function ProductHotkeys() {
 	const {
-		productSelection,
-		setShowCreateProductModal,
-		setShowUpdateProductModal,
-		setShowArchiveProductModal,
-		setShowDeleteProductModal,
+		selection,
+		setShowCreateModal,
+		setShowUpdateModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
 	} = useProductContext();
 
 	useModalHotKeys({
-		setShowCreateModal: setShowCreateProductModal,
-		setShowUpdateModal: setShowUpdateProductModal,
-		setShowArchiveModal: setShowArchiveProductModal,
-		setShowDeleteModal: setShowDeleteProductModal,
-		itemSelected: productSelection !== 'all' && !!productSelection.size,
+		setShowCreateModal,
+		setShowUpdateModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
+		itemSelected: selection !== 'all' && !!selection.size,
 	});
 
 	return null;

--- a/apps/app/src/app/[handle]/tracks/_components/all-tracks.tsx
+++ b/apps/app/src/app/[handle]/tracks/_components/all-tracks.tsx
@@ -2,6 +2,7 @@
 
 import type { AppRouterOutputs } from '@barely/lib/server/api/router';
 
+import { GridListSkeleton } from '@barely/ui/components/grid-list-skeleton';
 import { NoResultsPlaceholder } from '@barely/ui/components/no-results-placeholder';
 import { GridList, GridListCard } from '@barely/ui/elements/grid-list';
 import { Img } from '@barely/ui/elements/img';
@@ -12,12 +13,13 @@ import { useTrackContext } from '~/app/[handle]/tracks/_components/track-context
 
 export function AllTracks() {
 	const {
-		tracks,
-		trackSelection,
-		lastSelectedTrackId,
-		setTrackSelection,
+		items,
+		selection,
+		lastSelectedItemId,
+		setSelection,
 		gridListRef,
-		setShowEditTrackModal,
+		setShowUpdateModal,
+		isFetching,
 	} = useTrackContext();
 
 	return (
@@ -29,22 +31,24 @@ export function AllTracks() {
 			selectionMode='multiple'
 			selectionBehavior='replace'
 			// tracks
-			items={tracks}
-			selectedKeys={trackSelection}
-			setSelectedKeys={setTrackSelection}
+			items={items}
+			selectedKeys={selection}
+			setSelectedKeys={setSelection}
 			onAction={() => {
-				if (!lastSelectedTrackId) return;
-				setShowEditTrackModal(true);
+				if (!lastSelectedItemId) return;
+				setShowUpdateModal(true);
 			}}
 			// empty
-			renderEmptyState={() => (
-				<NoResultsPlaceholder
-					icon='track'
-					title='No tracks found.'
-					subtitle='Create a new track to get started.'
-					button={<CreateTrackButton />}
-				/>
-			)}
+			renderEmptyState={() =>
+				isFetching ?
+					<GridListSkeleton />
+				:	<NoResultsPlaceholder
+						icon='track'
+						title='No tracks found.'
+						subtitle='Create a new track to get started.'
+						button={<CreateTrackButton />}
+					/>
+			}
 		>
 			{track => <TrackCard track={track} />}
 		</GridList>
@@ -56,7 +60,7 @@ function TrackCard({
 }: {
 	track: AppRouterOutputs['track']['byWorkspace']['tracks'][number];
 }) {
-	const { setShowEditTrackModal, setShowArchiveTrackModal, setShowDeleteTrackModal } =
+	const { setShowUpdateModal, setShowArchiveModal, setShowDeleteModal } =
 		useTrackContext();
 
 	return (
@@ -64,9 +68,9 @@ function TrackCard({
 			id={track.id}
 			key={track.id}
 			textValue={track.name}
-			setShowUpdateModal={setShowEditTrackModal}
-			setShowArchiveModal={setShowArchiveTrackModal}
-			setShowDeleteModal={setShowDeleteTrackModal}
+			setShowUpdateModal={setShowUpdateModal}
+			setShowArchiveModal={setShowArchiveModal}
+			setShowDeleteModal={setShowDeleteModal}
 		>
 			<div className='flex flex-grow flex-row items-center gap-4'>
 				<div className='flex flex-col items-start gap-1'>

--- a/apps/app/src/app/[handle]/tracks/_components/archive-or-delete-track-modal.tsx
+++ b/apps/app/src/app/[handle]/tracks/_components/archive-or-delete-track-modal.tsx
@@ -8,20 +8,19 @@ import { useTrackContext } from '~/app/[handle]/tracks/_components/track-context
 
 export function ArchiveOrDeleteTrackModal({ mode }: { mode: 'archive' | 'delete' }) {
 	const {
-		trackSelection,
-		lastSelectedTrack,
-		showArchiveTrackModal,
-		showDeleteTrackModal,
-		setShowArchiveTrackModal,
-		setShowDeleteTrackModal,
+		selection,
+		lastSelectedItem,
+		showArchiveModal,
+		showDeleteModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
 	} = useTrackContext();
 
 	const apiUtils = api.useUtils();
 
-	const showModal = mode === 'archive' ? showArchiveTrackModal : showDeleteTrackModal;
+	const showModal = mode === 'archive' ? showArchiveModal : showDeleteModal;
 
-	const setShowModal =
-		mode === 'archive' ? setShowArchiveTrackModal : setShowDeleteTrackModal;
+	const setShowModal = mode === 'archive' ? setShowArchiveModal : setShowDeleteModal;
 
 	const onSuccess = useCallback(async () => {
 		await apiUtils.track.invalidate();
@@ -34,13 +33,13 @@ export function ArchiveOrDeleteTrackModal({ mode }: { mode: 'archive' | 'delete'
 	const { mutate: deleteTracks, isPending: isPendingDelete } =
 		api.track.delete.useMutation({ onSuccess });
 
-	if (!lastSelectedTrack) return null;
+	if (!lastSelectedItem) return null;
 
 	return (
 		<ArchiveOrDeleteModal
 			mode={mode}
-			selection={trackSelection}
-			lastSelected={lastSelectedTrack}
+			selection={selection}
+			lastSelected={lastSelectedItem}
 			showModal={showModal}
 			setShowModal={setShowModal}
 			archiveItems={archiveTracks}

--- a/apps/app/src/app/[handle]/tracks/_components/create-or-update-track-modal.tsx
+++ b/apps/app/src/app/[handle]/tracks/_components/create-or-update-track-modal.tsx
@@ -37,11 +37,11 @@ export function CreateOrUpdateTrackModal(props: { mode: 'create' | 'update' }) {
 
 	/* track context */
 	const {
-		lastSelectedTrack: selectedTrack,
-		showCreateTrackModal,
-		setShowCreateTrackModal,
-		showEditTrackModal,
-		setShowEditTrackModal,
+		lastSelectedItem: selectedTrack,
+		showCreateModal,
+		setShowCreateModal,
+		showUpdateModal,
+		setShowUpdateModal,
 		focusGridList,
 	} = useTrackContext();
 
@@ -167,9 +167,8 @@ export function CreateOrUpdateTrackModal(props: { mode: 'create' | 'update' }) {
 		mode === 'update' ? selectedTrack?.audioFiles?.find(f => f.masterWav) : undefined;
 
 	/* modal */
-	const showModal = mode === 'create' ? showCreateTrackModal : showEditTrackModal;
-	const setShowModal =
-		mode === 'create' ? setShowCreateTrackModal : setShowEditTrackModal;
+	const showModal = mode === 'create' ? showCreateModal : showUpdateModal;
+	const setShowModal = mode === 'create' ? setShowCreateModal : setShowUpdateModal;
 
 	const handleCloseModal = useCallback(async () => {
 		form.reset();

--- a/apps/app/src/app/[handle]/tracks/_components/create-track-button.tsx
+++ b/apps/app/src/app/[handle]/tracks/_components/create-track-button.tsx
@@ -5,12 +5,12 @@ import { Button } from '@barely/ui/elements/button';
 import { useTrackContext } from '~/app/[handle]/tracks/_components/track-context';
 
 export function CreateTrackButton() {
-	const { setShowCreateTrackModal } = useTrackContext();
+	const { setShowCreateModal } = useTrackContext();
 
 	return (
 		<Button
 			onClick={() => {
-				setShowCreateTrackModal(true);
+				setShowCreateModal(true);
 			}}
 			className='space-x-3'
 		>

--- a/apps/app/src/app/[handle]/tracks/_components/track-hotkeys.tsx
+++ b/apps/app/src/app/[handle]/tracks/_components/track-hotkeys.tsx
@@ -6,19 +6,19 @@ import { useTrackContext } from '~/app/[handle]/tracks/_components/track-context
 
 export function TrackHotkeys() {
 	const {
-		trackSelection,
-		setShowArchiveTrackModal,
-		setShowDeleteTrackModal,
-		setShowCreateTrackModal,
-		setShowEditTrackModal,
+		selection,
+		setShowArchiveModal,
+		setShowDeleteModal,
+		setShowCreateModal,
+		setShowUpdateModal,
 	} = useTrackContext();
 
 	useModalHotKeys({
-		setShowCreateModal: setShowCreateTrackModal,
-		setShowUpdateModal: setShowEditTrackModal,
-		setShowArchiveModal: setShowArchiveTrackModal,
-		setShowDeleteModal: setShowDeleteTrackModal,
-		itemSelected: trackSelection !== 'all' && !!trackSelection.size,
+		setShowCreateModal,
+		setShowUpdateModal,
+		setShowArchiveModal,
+		setShowDeleteModal,
+		itemSelected: selection !== 'all' && !!selection.size,
 	});
 
 	return null;

--- a/packages/lib/hooks/use-files.ts
+++ b/packages/lib/hooks/use-files.ts
@@ -12,7 +12,15 @@ type UseFilesProps = Omit<
 export function useFiles(props?: UseFilesProps) {
 	const { handle } = useWorkspace();
 
-	const infiniteFilesQuery = api.file.byWorkspace.useInfiniteQuery(
+	const {
+		data,
+		hasNextPage,
+		fetchNextPage,
+		isFetchingNextPage,
+		isFetching,
+		isRefetching,
+		isPending,
+	} = api.file.byWorkspace.useInfiniteQuery(
 		{
 			handle,
 			...props,
@@ -22,12 +30,15 @@ export function useFiles(props?: UseFilesProps) {
 		},
 	);
 
-	const files = infiniteFilesQuery.data?.pages.flatMap(page => page.files) ?? [];
+	const files = data?.pages.flatMap(page => page.files) ?? [];
 
 	return {
 		files,
-		hasMoreFiles: !!infiniteFilesQuery.hasNextPage,
-		fetchMoreFiles: infiniteFilesQuery.fetchNextPage,
-		_query: infiniteFilesQuery,
+		hasMoreFiles: !!hasNextPage,
+		fetchMoreFiles: fetchNextPage,
+		isFetchingNextPage,
+		isFetching,
+		isRefetching,
+		isPending,
 	};
 }

--- a/packages/lib/hooks/use-modal-hot-keys.ts
+++ b/packages/lib/hooks/use-modal-hot-keys.ts
@@ -1,4 +1,7 @@
 import { useCallback, useEffect } from 'react';
+import { useAtom } from 'jotai';
+
+import { gKeyPressedAtom } from './use-workspace-hotkeys';
 
 interface CustomHotkey {
 	condition: (e: KeyboardEvent) => boolean;
@@ -39,11 +42,14 @@ export function useModalHotKeys({
 
 	customHotkeys?: CustomHotkey[];
 }) {
+	const [gKeyPressed] = useAtom(gKeyPressedAtom);
+
 	const onKeydown = useCallback(
 		(e: KeyboardEvent) => {
 			const target = e.target as HTMLElement;
 			const existingModalBackdrop = document.getElementById('modal-backdrop');
 
+			// console.log('gKeyPressed in modal hotkeys', gKeyPressed);
 			/* create */
 			// only open add--modal w/ keyboard shortcut if:
 			// - c is pressed
@@ -51,6 +57,7 @@ export function useModalHotKeys({
 			// - user is not typing in an input or textarea
 			// - there is no existing modal backdrop (i.e. no other modal is open)
 			if (
+				!gKeyPressed &&
 				e.key === 'c' &&
 				!e.metaKey &&
 				!e.ctrlKey &&
@@ -144,6 +151,7 @@ export function useModalHotKeys({
 			archiveDisabled,
 			createDisabled,
 			updateDisabled,
+			gKeyPressed,
 		],
 	);
 

--- a/packages/lib/hooks/use-pathname-matches-current-path.ts
+++ b/packages/lib/hooks/use-pathname-matches-current-path.ts
@@ -5,3 +5,9 @@ export function usePathnameMatchesCurrentPath(path: string) {
 
 	return pathname ? pathname === path : false;
 }
+
+export function usePathnameEndsWith(path: string) {
+	const pathname = usePathname() as null | string;
+
+	return pathname ? pathname.endsWith(path) : false;
+}

--- a/packages/lib/hooks/use-workspace-hotkeys.tsx
+++ b/packages/lib/hooks/use-workspace-hotkeys.tsx
@@ -1,12 +1,16 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { useAtom } from 'jotai';
 
 import type { SessionWorkspace } from '../server/auth';
+import { atomWithToggle } from '../atoms/atom-with-toggle';
+
+export const gKeyPressedAtom = atomWithToggle(false);
 
 export function useWorkspaceHotkeys({ workspace }: { workspace: SessionWorkspace }) {
 	const router = useRouter();
 
-	const [gKeyPressed, setGKeyPressed] = useState(false);
+	const [gKeyPressed, setGKeyPressed] = useAtom(gKeyPressedAtom);
 
 	const handleKeyDown = useCallback(
 		(e: KeyboardEvent) => {
@@ -22,10 +26,15 @@ export function useWorkspaceHotkeys({ workspace }: { workspace: SessionWorkspace
 				setGKeyPressed(true);
 				setTimeout(() => {
 					setGKeyPressed(false);
-				}, 500); // Reset gKeyPressed after 0.5 seconds
+				}, 600); // Reset gKeyPressed after 0.5 seconds
 			}
+
 			if (e.key === 'c' && gKeyPressed && noMetaKey && notInInput) {
 				router.push(`/${workspace.handle}/carts`);
+				setGKeyPressed(false);
+			}
+			if (e.key === 'f' && gKeyPressed && noMetaKey && notInInput) {
+				router.push(`/${workspace.handle}/fm`);
 				setGKeyPressed(false);
 			}
 			if (e.key === 'l' && gKeyPressed && noMetaKey && notInInput) {
@@ -34,6 +43,10 @@ export function useWorkspaceHotkeys({ workspace }: { workspace: SessionWorkspace
 			}
 			if (e.key === 'm' && gKeyPressed && noMetaKey && notInInput) {
 				router.push(`/${workspace.handle}/media`);
+				setGKeyPressed(false);
+			}
+			if (e.key === 'o' && gKeyPressed && noMetaKey && notInInput) {
+				router.push(`/${workspace.handle}/orders`);
 				setGKeyPressed(false);
 			}
 			if (e.key === 'p' && gKeyPressed && noMetaKey && notInInput) {
@@ -46,6 +59,10 @@ export function useWorkspaceHotkeys({ workspace }: { workspace: SessionWorkspace
 			}
 			if (e.key === 't' && gKeyPressed && noMetaKey && notInInput) {
 				router.push(`/${workspace.handle}/tracks`);
+				setGKeyPressed(false);
+			}
+			if (e.key === 'w' && gKeyPressed && noMetaKey && notInInput) {
+				router.push(`/${workspace.handle}/flows`);
 				setGKeyPressed(false);
 			}
 			if (e.key === 'x' && gKeyPressed && noMetaKey && notInInput) {

--- a/packages/lib/hooks/use-workspace.ts
+++ b/packages/lib/hooks/use-workspace.ts
@@ -1,6 +1,7 @@
-import { useContext } from 'react';
-import { useParams } from 'next/navigation';
+import { useCallback, useContext } from 'react';
+import { useParams, usePathname, useRouter } from 'next/navigation';
 
+import type { SessionWorkspace } from '../server/auth';
 import { WorkspaceContext } from '../context/workspace.context';
 import { api } from '../server/api/react';
 import { useSubscribe } from './use-subscribe';
@@ -13,6 +14,320 @@ export function useWorkspaceHandle() {
 	if (typeof handle === 'string') return handle;
 
 	return null;
+}
+
+export function useSetWorkspace({ onBeginSet }: { onBeginSet?: () => void }) {
+	const router = useRouter();
+	const apiUtils = api.useUtils();
+	const currentWorkspace = useWorkspace();
+	const currentPath = usePathname();
+
+	const setCurrentWorkspace = useCallback(
+		async (workspace: SessionWorkspace) => {
+			console.log('setting current workspace to', workspace, '@', Date.now());
+			apiUtils.workspace.current.setData(undefined, workspace);
+
+			// apiUtils.cancel()
+
+			console.log('currentPath', currentPath);
+
+			if (currentPath?.endsWith('carts')) {
+				apiUtils.cartFunnel.byWorkspace.setInfiniteData(
+					{ handle: workspace.handle },
+					apiUtils.cartFunnel.byWorkspace.getInfiniteData({
+						handle: workspace.handle,
+					}) ?? {
+						pages: [
+							{
+								cartFunnels: [],
+								nextCursor: undefined,
+							},
+						],
+						pageParams: [],
+					},
+				);
+
+				await apiUtils.cartFunnel.invalidate();
+			}
+
+			if (currentPath?.endsWith('email-broadcasts')) {
+				apiUtils.emailBroadcast.byWorkspace.setInfiniteData(
+					{ handle: workspace.handle },
+					apiUtils.emailBroadcast.byWorkspace.getInfiniteData({
+						handle: workspace.handle,
+					}) ?? {
+						pages: [
+							{
+								emailBroadcasts: [],
+								nextCursor: undefined,
+							},
+						],
+						pageParams: [],
+					},
+				);
+			}
+
+			if (currentPath?.endsWith('email-templates')) {
+				apiUtils.emailTemplate.byWorkspace.setInfiniteData(
+					{ handle: workspace.handle },
+					apiUtils.emailTemplate.byWorkspace.getInfiniteData({
+						handle: workspace.handle,
+					}) ?? {
+						pages: [
+							{
+								emailTemplates: [],
+								nextCursor: undefined,
+							},
+						],
+						pageParams: [],
+					},
+				);
+
+				await apiUtils.emailTemplate.byWorkspace.invalidate();
+			}
+
+			if (currentPath?.endsWith('email-template-groups')) {
+				apiUtils.emailTemplateGroup.byWorkspace.setInfiniteData(
+					{ handle: workspace.handle },
+					apiUtils.emailTemplateGroup.byWorkspace.getInfiniteData({
+						handle: workspace.handle,
+					}) ?? {
+						pages: [
+							{
+								emailTemplateGroups: [],
+								nextCursor: undefined,
+							},
+						],
+						pageParams: [],
+					},
+				);
+
+				await apiUtils.emailTemplateGroup.byWorkspace.invalidate();
+			}
+
+			if (currentPath?.endsWith('fan-groups')) {
+				apiUtils.fanGroup.byWorkspace.setInfiniteData(
+					{ handle: workspace.handle },
+					apiUtils.fanGroup.byWorkspace.getInfiniteData({
+						handle: workspace.handle,
+					}) ?? {
+						pages: [
+							{
+								fanGroups: [],
+								nextCursor: undefined,
+							},
+						],
+						pageParams: [],
+					},
+				);
+
+				await apiUtils.fanGroup.byWorkspace.invalidate();
+			}
+
+			if (currentPath?.endsWith('fans')) {
+				apiUtils.fan.byWorkspace.setInfiniteData(
+					{ handle: workspace.handle },
+					apiUtils.fan.byWorkspace.getInfiniteData({
+						handle: workspace.handle,
+					}) ?? {
+						pages: [
+							{
+								fans: [],
+								nextCursor: undefined,
+							},
+						],
+						pageParams: [],
+					},
+				);
+
+				await apiUtils.fan.byWorkspace.invalidate();
+			}
+
+			if (currentPath?.endsWith('flows')) {
+				apiUtils.flow.byWorkspace.setInfiniteData(
+					{ handle: workspace.handle },
+					apiUtils.flow.byWorkspace.getInfiniteData({
+						handle: workspace.handle,
+					}) ?? {
+						pages: [
+							{
+								flows: [],
+								nextCursor: undefined,
+							},
+						],
+						pageParams: [],
+					},
+				);
+
+				await apiUtils.flow.byWorkspace.invalidate();
+			}
+
+			if (currentPath?.endsWith('fm')) {
+				apiUtils.fm.byWorkspace.setInfiniteData(
+					{ handle: workspace.handle },
+					apiUtils.fm.byWorkspace.getInfiniteData({
+						handle: workspace.handle,
+					}) ?? {
+						pages: [
+							{
+								fmPages: [],
+								nextCursor: undefined,
+							},
+						],
+						pageParams: [],
+					},
+				);
+
+				await apiUtils.fm.byWorkspace.invalidate();
+			}
+
+			if (currentPath?.endsWith('links')) {
+				apiUtils.link.byWorkspace.setInfiniteData(
+					{ handle: workspace.handle },
+					apiUtils.link.byWorkspace.getInfiniteData({
+						handle: workspace.handle,
+					}) ?? {
+						pages: [
+							{
+								links: [],
+								nextCursor: undefined,
+							},
+						],
+						pageParams: [],
+					},
+				);
+
+				await apiUtils.link.byWorkspace.invalidate();
+			}
+
+			if (currentPath?.endsWith('media')) {
+				apiUtils.file.byWorkspace.setInfiniteData(
+					{ handle: workspace.handle },
+					apiUtils.file.byWorkspace.getInfiniteData({
+						handle: workspace.handle,
+					}) ?? {
+						pages: [
+							{
+								files: [],
+								nextCursor: undefined,
+							},
+						],
+						pageParams: [],
+					},
+				);
+
+				await apiUtils.file.byWorkspace.invalidate();
+			}
+
+			if (currentPath?.endsWith('mixtapes')) {
+				apiUtils.mixtape.byWorkspace.setInfiniteData(
+					{ handle: workspace.handle },
+					apiUtils.mixtape.byWorkspace.getInfiniteData({
+						handle: workspace.handle,
+					}) ?? {
+						pages: [
+							{
+								mixtapes: [],
+								nextCursor: undefined,
+							},
+						],
+						pageParams: [],
+					},
+				);
+
+				await apiUtils.mixtape.byWorkspace.invalidate();
+			}
+
+			if (currentPath?.endsWith('orders')) {
+				apiUtils.cartOrder.byWorkspace.setInfiniteData(
+					{ handle: workspace.handle },
+					apiUtils.cartOrder.byWorkspace.getInfiniteData({
+						handle: workspace.handle,
+					}) ?? {
+						pages: [
+							{
+								cartOrders: [],
+								nextCursor: undefined,
+							},
+						],
+						pageParams: [],
+					},
+				);
+
+				await apiUtils.cartOrder.byWorkspace.invalidate();
+			}
+
+			if (currentPath?.endsWith('pages')) {
+				apiUtils.landingPage.byWorkspace.setInfiniteData(
+					{ handle: workspace.handle },
+					apiUtils.landingPage.byWorkspace.getInfiniteData({
+						handle: workspace.handle,
+					}) ?? {
+						pages: [
+							{
+								landingPages: [],
+								nextCursor: undefined,
+							},
+						],
+						pageParams: [],
+					},
+				);
+
+				await apiUtils.landingPage.byWorkspace.invalidate();
+			}
+
+			if (currentPath?.endsWith('products')) {
+				apiUtils.product.byWorkspace.setInfiniteData(
+					{ handle: workspace.handle },
+					apiUtils.product.byWorkspace.getInfiniteData({
+						handle: workspace.handle,
+					}) ?? {
+						pages: [
+							{
+								products: [],
+								nextCursor: undefined,
+							},
+						],
+						pageParams: [],
+					},
+				);
+
+				await apiUtils.product.byWorkspace.invalidate();
+			}
+
+			if (currentPath?.endsWith('tracks')) {
+				apiUtils.track.byWorkspace.setInfiniteData(
+					{ handle: workspace.handle },
+					apiUtils.track.byWorkspace.getInfiniteData({
+						handle: workspace.handle,
+					}) ?? {
+						pages: [
+							{
+								tracks: [],
+								nextCursor: undefined,
+							},
+						],
+						pageParams: [],
+					},
+				);
+
+				await apiUtils.track.byWorkspace.invalidate();
+			}
+
+			onBeginSet?.();
+
+			if (currentWorkspace.handle === workspace.handle) return;
+			if (currentPath) {
+				router.push(currentPath.replace(currentWorkspace.handle, workspace.handle));
+				return console.log('pushed @', Date.now());
+			}
+			router.push(`/${workspace.handle}`);
+			console.log('pushed @', Date.now());
+		},
+		[apiUtils, currentPath, currentWorkspace, router, onBeginSet],
+	);
+
+	return { setCurrentWorkspace };
 }
 
 export function useWorkspace() {
@@ -53,7 +368,3 @@ export function useWorkspaceIsPersonal() {
 
 	return workspace.type === 'personal';
 }
-
-// export const usePossibleWorkspace = () => {
-// 	return useAtomValue(workspaceAtom);
-// };

--- a/packages/lib/server/routes/workspace/workspace.router.ts
+++ b/packages/lib/server/routes/workspace/workspace.router.ts
@@ -27,6 +27,22 @@ import {
 import { Workspaces } from './workspace.sql';
 
 export const workspaceRouter = createTRPCRouter({
+	// byHandle: privateProcedure
+	// 	.input(z.object({ handle: z.string() }))
+	// 	.query(async ({ input, ctx }) => {
+	// 		const workspace = await ctx.db.http.query.Workspaces.findFirst({
+	// 			where: and(
+	// 				eq(Workspaces.handle, input.handle),
+	// 				inArray(
+	// 					Workspaces.id,
+	// 					ctx.user.workspaces.map(w => w.id),
+	// 				),
+	// 			),
+	// 		});
+
+	// 		return workspace;
+	// 	}),
+
 	current: privateProcedure.query(({ ctx }) => {
 		if (!ctx.workspace) return null;
 		return ctx.workspace;
@@ -77,43 +93,31 @@ export const workspaceRouter = createTRPCRouter({
 			return assets;
 		}),
 
-	members: workspaceQueryProcedure
-		// .input(
-		// 	z.object({
-		// 		handle: z.string(),
-		// 	}),
-		// )
-		.query(async ({ ctx }) => {
-			const members = await ctx.db.http.query._Users_To_Workspaces.findMany({
-				where: eq(_Users_To_Workspaces.workspaceId, ctx.workspace.id),
-				limit: 20,
-				with: {
-					user: true,
-				},
-			});
+	members: workspaceQueryProcedure.query(async ({ ctx }) => {
+		const members = await ctx.db.http.query._Users_To_Workspaces.findMany({
+			where: eq(_Users_To_Workspaces.workspaceId, ctx.workspace.id),
+			limit: 20,
+			with: {
+				user: true,
+			},
+		});
 
-			return members.map(m => ({
-				...m.user,
-				role: m.role,
-			}));
-		}),
+		return members.map(m => ({
+			...m.user,
+			role: m.role,
+		}));
+	}),
 
-	invites: workspaceQueryProcedure
-		// .input(
-		// 	z.object({
-		// 		handle: z.string(),
-		// 	}),
-		// )
-		.query(async ({ ctx }) => {
-			const invites = await ctx.db.http.query.WorkspaceInvites.findMany({
-				where: and(
-					eq(WorkspaceInvites.workspaceId, ctx.workspace.id),
-					gt(WorkspaceInvites.expiresAt, new Date()),
-				),
-			});
+	invites: workspaceQueryProcedure.query(async ({ ctx }) => {
+		const invites = await ctx.db.http.query.WorkspaceInvites.findMany({
+			where: and(
+				eq(WorkspaceInvites.workspaceId, ctx.workspace.id),
+				gt(WorkspaceInvites.expiresAt, new Date()),
+			),
+		});
 
-			return invites;
-		}),
+		return invites;
+	}),
 
 	create: privateProcedure
 		.input(createWorkspaceSchema)

--- a/packages/ui/components/grid-list-skeleton.tsx
+++ b/packages/ui/components/grid-list-skeleton.tsx
@@ -1,0 +1,9 @@
+export function GridListSkeleton({ count = 4 }: { count?: number }) {
+	return (
+		<div className='flex flex-col gap-2'>
+			{Array.from({ length: count }).map((_, index) => (
+				<div key={index} className='h-20 w-full animate-pulse rounded-lg bg-muted' />
+			))}
+		</div>
+	);
+}


### PR DESCRIPTION
- standardized infinite item context
- when workspace is switched, immediately switch to existing query data for that workspace (if it exists, even if stale) or set to empty (if that query hasn't been run yet). then invalidate route. this is currently done for all {item}.byWorkspace routers
- use GridSkeleton for empty placeholder if query is actively fetching