### PR TITLE
added hue picker & simplified workspace settings forms

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -54,6 +54,7 @@
 		"react-hook-form": "^7.45.4",
 		"remeda": "^1.24.0",
 		"sharp": "^0.33.2",
+		"simple-hue-picker": "^0.2.0",
 		"superjson": "^2.2.1",
 		"svix": "^1.35.0",
 		"tailwindcss-animate": "^1.0.7",

--- a/apps/app/src/app/[handle]/settings/cart/cart-settings.tsx
+++ b/apps/app/src/app/[handle]/settings/cart/cart-settings.tsx
@@ -1,12 +1,33 @@
 'use client';
 
-import { useWorkspaceUpdateForm } from '@barely/lib/hooks/use-workspace-update-form';
+import type { z } from 'zod';
+import { useUpdateWorkspace } from '@barely/lib/hooks/use-update-workspace';
+import { useWorkspace } from '@barely/lib/hooks/use-workspace';
+// import { useWorkspaceUpdateForm } from '@barely/lib/hooks/use-workspace-update-form';
+import { useZodForm } from '@barely/lib/hooks/use-zod-form';
+import { updateWorkspaceSchema } from '@barely/lib/server/routes/workspace/workspace.schema';
 
 import { SettingsCardForm } from '@barely/ui/components/settings-card';
 import { TextField } from '@barely/ui/forms/text-field';
 
 export function CartShippingAddress() {
-	const { form, onSubmit } = useWorkspaceUpdateForm();
+	const { workspace } = useWorkspace();
+
+	const form = useZodForm({
+		schema: updateWorkspaceSchema,
+		values: {
+			id: workspace.id,
+			shippingAddressLine1: workspace.shippingAddressLine1,
+		},
+	});
+
+	const { updateWorkspace } = useUpdateWorkspace({
+		onSuccess: () => form.reset(),
+	});
+
+	const onSubmit = async (data: z.infer<typeof updateWorkspaceSchema>) => {
+		await updateWorkspace(data);
+	};
 
 	return (
 		<SettingsCardForm
@@ -39,7 +60,23 @@ export function CartShippingAddress() {
 }
 
 export function CartSupportEmail() {
-	const { form, onSubmit } = useWorkspaceUpdateForm();
+	const { workspace } = useWorkspace();
+
+	const form = useZodForm({
+		schema: updateWorkspaceSchema,
+		values: {
+			id: workspace.id,
+			cartSupportEmail: workspace.cartSupportEmail,
+		},
+	});
+
+	const { updateWorkspace } = useUpdateWorkspace({
+		onSuccess: () => form.reset(),
+	});
+
+	const onSubmit = async (data: z.infer<typeof updateWorkspaceSchema>) => {
+		await updateWorkspace(data);
+	};
 
 	return (
 		<SettingsCardForm

--- a/apps/app/src/app/[handle]/settings/page.tsx
+++ b/apps/app/src/app/[handle]/settings/page.tsx
@@ -4,6 +4,7 @@ import {
 	HandleForm,
 	WorkspaceAvatarForm,
 	WorkspaceBioForm,
+	WorkspaceBrandHuesForm,
 	WorkspaceHeaderForm,
 	WorkspaceTypeForm,
 } from '~/app/[handle]/settings/workspace-profile-settings';
@@ -18,6 +19,7 @@ export default function WorkspaceProfileSettingsPage() {
 			<WorkspaceHeaderForm />
 			<WorkspaceTypeForm />
 			<WorkspaceBioForm />
+			<WorkspaceBrandHuesForm />
 		</>
 	);
 }

--- a/apps/app/src/app/[handle]/settings/socials/social-settings.tsx
+++ b/apps/app/src/app/[handle]/settings/socials/social-settings.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import { useWorkspaceUpdateForm } from '@barely/lib/hooks/use-workspace-update-form';
+import type { z } from 'zod';
+import { useUpdateWorkspace } from '@barely/lib/hooks/use-update-workspace';
+import { useWorkspace } from '@barely/lib/hooks/use-workspace';
+// import { useWorkspaceUpdateForm } from '@barely/lib/hooks/use-workspace-update-form';
+import { useZodForm } from '@barely/lib/hooks/use-zod-form';
+import { updateWorkspaceSchema } from '@barely/lib/server/routes/workspace/workspace.schema';
 import {
 	isValidUrl,
 	parseInstagramLink,
@@ -14,7 +19,28 @@ import { NumberField } from '@barely/ui/forms/number-field';
 import { TextField } from '@barely/ui/forms/text-field';
 
 export function SocialStatsForm() {
-	const { form, onSubmit } = useWorkspaceUpdateForm();
+	const { workspace } = useWorkspace();
+
+	const form = useZodForm({
+		schema: updateWorkspaceSchema,
+		values: {
+			id: workspace.id,
+			facebookFollowers: workspace.facebookFollowers,
+			instagramFollowers: workspace.instagramFollowers,
+			spotifyFollowers: workspace.spotifyFollowers,
+			spotifyMonthlyListeners: workspace.spotifyMonthlyListeners,
+			twitterFollowers: workspace.twitterFollowers,
+			youtubeSubscribers: workspace.youtubeSubscribers,
+		},
+	});
+
+	const { updateWorkspace } = useUpdateWorkspace({
+		onSuccess: () => form.reset(),
+	});
+
+	const onSubmit = async (data: z.infer<typeof updateWorkspaceSchema>) => {
+		await updateWorkspace(data);
+	};
 
 	return (
 		<SettingsCardForm
@@ -65,7 +91,27 @@ export function SocialStatsForm() {
 }
 
 export function SocialLinksForm() {
-	const { form, onSubmit } = useWorkspaceUpdateForm();
+	const { workspace } = useWorkspace();
+
+	const form = useZodForm({
+		schema: updateWorkspaceSchema,
+		values: {
+			id: workspace.id,
+			spotifyArtistId: workspace.spotifyArtistId,
+			youtubeChannelId: workspace.youtubeChannelId,
+			tiktokUsername: workspace.tiktokUsername,
+			instagramUsername: workspace.instagramUsername,
+			website: workspace.website,
+		},
+	});
+
+	const { updateWorkspace } = useUpdateWorkspace({
+		onSuccess: () => form.reset(),
+	});
+
+	const onSubmit = async (data: z.infer<typeof updateWorkspaceSchema>) => {
+		await updateWorkspace(data);
+	};
 
 	return (
 		<SettingsCardForm

--- a/apps/app/src/app/[handle]/settings/workspace-profile-settings.tsx
+++ b/apps/app/src/app/[handle]/settings/workspace-profile-settings.tsx
@@ -7,9 +7,13 @@ import type { MDXEditorMethods } from '@barely/ui/elements/mdx-editor';
 import type { SelectFieldOption } from '@barely/ui/forms/select-field';
 import type { z } from 'zod';
 import { useCallback, useRef } from 'react';
+import { useUpdateWorkspace } from '@barely/lib/hooks/use-update-workspace';
 import { useUpload } from '@barely/lib/hooks/use-upload';
+import { useZodForm } from '@barely/lib/hooks/use-zod-form';
+import { updateWorkspaceSchema } from '@barely/lib/server/routes/workspace/workspace.schema';
 import { api } from '@barely/server/api/react';
 import { atom } from 'jotai';
+import HuePicker from 'simple-hue-picker/react';
 
 import { useWorkspace } from '@barely/hooks/use-workspace';
 import { useWorkspaceUpdateForm } from '@barely/hooks/use-workspace-update-form';
@@ -23,7 +27,24 @@ import { SelectField } from '@barely/ui/forms/select-field';
 import { TextField } from '@barely/ui/forms/text-field';
 
 export function DisplayOrWorkspaceNameForm() {
-	const { form, onSubmit, isPersonal } = useWorkspaceUpdateForm();
+	const { workspace, isPersonal } = useWorkspace();
+
+	const form = useZodForm({
+		schema: updateWorkspaceSchema,
+		values: {
+			id: workspace.id,
+			name: workspace.name,
+		},
+		resetOptions: { keepDirtyValues: true },
+	});
+
+	const { updateWorkspace } = useUpdateWorkspace({
+		onSuccess: () => form.reset(),
+	});
+
+	const onSubmit = async (data: z.infer<typeof updateWorkspaceSchema>) => {
+		await updateWorkspace(data);
+	};
 
 	return (
 		<SettingsCardForm
@@ -44,7 +65,28 @@ export function DisplayOrWorkspaceNameForm() {
 }
 
 export function HandleForm() {
-	const { form, onSubmit, isPersonal } = useWorkspaceUpdateForm();
+	// const { form, onSubmit, isPersonal } = useWorkspaceUpdateForm({
+	// 	updateKeys: ['handle'],
+	// });
+
+	const { workspace, isPersonal } = useWorkspace();
+
+	const form = useZodForm({
+		schema: updateWorkspaceSchema,
+		values: {
+			id: workspace.id,
+			handle: workspace.handle,
+		},
+		resetOptions: { keepDirtyValues: true },
+	});
+
+	const { updateWorkspace } = useUpdateWorkspace({
+		onSuccess: () => form.reset(),
+	});
+
+	const onSubmit = async (data: z.infer<typeof updateWorkspaceSchema>) => {
+		await updateWorkspace(data);
+	};
 
 	return (
 		<SettingsCardForm
@@ -88,7 +130,24 @@ export function HandleForm() {
 }
 
 export function WorkspaceTypeForm() {
-	const { form, onSubmit, isPersonal } = useWorkspaceUpdateForm();
+	const { workspace, isPersonal } = useWorkspace();
+
+	const form = useZodForm({
+		schema: updateWorkspaceSchema,
+		values: {
+			id: workspace.id,
+			type: workspace.type,
+		},
+		resetOptions: { keepDirtyValues: true },
+	});
+
+	const { updateWorkspace } = useUpdateWorkspace({
+		onSuccess: () => form.reset(),
+	});
+
+	const onSubmit = async (data: z.infer<typeof updateWorkspaceSchema>) => {
+		await updateWorkspace(data);
+	};
 
 	if (isPersonal) {
 		return null;
@@ -242,7 +301,9 @@ export function WorkspaceHeaderForm() {
 
 export function WorkspaceBioForm() {
 	const { workspace } = useWorkspace();
-	const { form, onSubmit, isPersonal } = useWorkspaceUpdateForm();
+	const { form, onSubmit, isPersonal } = useWorkspaceUpdateForm({
+		updateKeys: ['bio'],
+	});
 
 	const ref = useRef<MDXEditorMethods>(null);
 
@@ -265,6 +326,55 @@ export function WorkspaceBioForm() {
 					form.setValue('bio', v, { shouldDirty: true });
 				}}
 			/>
+		</SettingsCardForm>
+	);
+}
+
+export function WorkspaceBrandHuesForm() {
+	// const { form, onSubmit, isPersonal } = useWorkspaceUpdateForm({
+	// 	updateKeys: ['brandHue'],
+	// });
+
+	const { workspace, isPersonal } = useWorkspace();
+
+	const form = useZodForm({
+		schema: updateWorkspaceSchema,
+		values: {
+			id: workspace.id,
+			brandHue: workspace.brandHue,
+		},
+		resetOptions: { keepDirtyValues: true },
+	});
+
+	const { updateWorkspace } = useUpdateWorkspace({
+		onSuccess: () => form.reset(),
+	});
+
+	const onSubmit = async (data: z.infer<typeof updateWorkspaceSchema>) => {
+		await updateWorkspace(data);
+	};
+
+	return (
+		<SettingsCardForm
+			form={form}
+			onSubmit={onSubmit}
+			title='Brand Hues'
+			subtitle={
+				isPersonal ?
+					'This is your personal brand hues on Barely.'
+				:	`This is your workspace's brand hues on Barely.`
+			}
+			disableSubmit={!form.formState.isDirty}
+		>
+			brandHue: {form.watch('brandHue')}
+			<HuePicker
+				step={10}
+				value={form.watch('brandHue')}
+				onChange={e => {
+					form.setValue('brandHue', e.detail, { shouldDirty: true });
+				}}
+			/>
+			{/* <pre>{JSON.stringify(form.formState.errors, null, 2)}</pre> */}
 		</SettingsCardForm>
 	);
 }

--- a/packages/lib/hooks/use-update-workspace.tsx
+++ b/packages/lib/hooks/use-update-workspace.tsx
@@ -1,0 +1,45 @@
+import { usePathname, useRouter } from 'next/navigation';
+
+import { api } from '../server/api/react';
+import { useWorkspace } from './use-workspace';
+
+export function useUpdateWorkspace({ onSuccess }: { onSuccess?: () => void } = {}) {
+	const { workspace } = useWorkspace();
+	const apiUtils = api.useUtils();
+	const router = useRouter();
+	const currentPath = usePathname();
+
+	const { mutateAsync: updateWorkspace } = api.workspace.update.useMutation({
+		onMutate: async data => {
+			console.log('onMutate', data);
+			await apiUtils.workspace.current.cancel();
+
+			const handleChanged = data.handle !== workspace.handle;
+
+			return {
+				handleChanged,
+				oldHandle: workspace.handle,
+				newHandle: data.handle,
+			};
+		},
+		onSuccess: async (data, variables, context) => {
+			if (
+				context?.handleChanged &&
+				context.oldHandle &&
+				context.newHandle &&
+				currentPath
+			) {
+				console.log(
+					'pushing to',
+					currentPath.replace(context.oldHandle, context.newHandle),
+				);
+				return router.push(currentPath.replace(context.oldHandle, context.newHandle));
+			}
+
+			await apiUtils.workspace.current.invalidate();
+			onSuccess?.();
+		},
+	});
+
+	return { updateWorkspace };
+}

--- a/packages/lib/hooks/use-workspace-update-form.ts
+++ b/packages/lib/hooks/use-workspace-update-form.ts
@@ -10,8 +10,26 @@ export function useWorkspaceUpdateForm() {
 	const { workspace } = useWorkspace();
 	const apiUtils = api.useUtils();
 
+	// const defaultValues: UpdateWorkspace = {
+	// 	id: workspace.id,
+	// };
+
+	// for (const key of updateKeys) {
+	// 	if (key in workspace) {
+	// 		defaultValues[key] = workspace[key] as UpdateWorkspace[typeof key];
+	// 	}
+	// }
+
+	// const updateValues = updateKeys.reduce<Partial<UpdateWorkspace>>((acc, key) => {
+	// 	if (key in workspace) {
+	// 		acc[key] = workspace[key] as UpdateWorkspace[keyof UpdateWorkspace];
+	// 	}
+	// 	return acc;
+	// }, {});
+
 	const form = useZodForm({
 		schema: updateWorkspaceSchema,
+		// defaultValues,
 		values: workspace,
 		resetOptions: {
 			keepDirtyValues: true, // retain user-interacted input
@@ -23,6 +41,7 @@ export function useWorkspaceUpdateForm() {
 
 	const { mutate: updateWorkspace } = api.workspace.update.useMutation({
 		onMutate: async data => {
+			console.log('onMutate', data);
 			await apiUtils.workspace.current.cancel();
 
 			const handleChanged = data.handle !== workspace.handle;
@@ -40,6 +59,10 @@ export function useWorkspaceUpdateForm() {
 				context.newHandle &&
 				currentPath
 			) {
+				console.log(
+					'pushing to',
+					currentPath.replace(context.oldHandle, context.newHandle),
+				);
 				return router.push(currentPath.replace(context.oldHandle, context.newHandle));
 			}
 

--- a/packages/lib/hooks/use-workspace.ts
+++ b/packages/lib/hooks/use-workspace.ts
@@ -27,10 +27,15 @@ export function useWorkspace({ onBeginSet }: { onBeginSet?: () => void } = {}) {
 		useContext(WorkspaceContext) ??
 		raise('useOptimisticWorkspace must be used within a WorkspaceProvider');
 
+	const { data: currentWorkspace } = api.workspace.current.useQuery(undefined, {
+		initialData: initialWorkspace,
+	});
+
 	const [pendingTransition, startTransition] = useTransition();
 
-	const [optimisticWorkspace, setOptimisticWorkspace] =
-		useOptimistic<SessionWorkspace>(initialWorkspace);
+	const [optimisticWorkspace, setOptimisticWorkspace] = useOptimistic<SessionWorkspace>(
+		currentWorkspace ?? initialWorkspace,
+	);
 
 	const setWorkspace = useCallback(
 		function (workspace: SessionWorkspace) {

--- a/packages/lib/server/auth/index.ts
+++ b/packages/lib/server/auth/index.ts
@@ -140,13 +140,13 @@ const authConfig: NextAuthConfig = {
 			return { ...session, user };
 		},
 		redirect: ({ url, baseUrl }) => {
-			console.log('redirect baseUrl => ', baseUrl);
-			console.log('redirect url => ', url);
+			// console.log('redirect baseUrl => ', baseUrl);
+			// console.log('redirect url => ', url);
 
 			if (url.startsWith('/')) return `${baseUrl}${url}`;
 
 			const origin = new URL(baseUrl).origin;
-			console.log('redirect origin => ', origin);
+			// console.log('redirect origin => ', origin);
 
 			if (
 				origin === baseUrl ||

--- a/packages/lib/server/routes/fm/fm.sql.ts
+++ b/packages/lib/server/routes/fm/fm.sql.ts
@@ -20,8 +20,9 @@ export const FmPages = pgTable('FmPages', {
 	handle: varchar('handle', { length: 255 })
 		.notNull()
 		.references(() => Workspaces.handle, {
-			onDelete: 'cascade',
+			onUpdate: 'cascade',
 		}),
+
 	key: varchar('key', { length: 255 }).notNull(),
 	// source
 	sourceUrl: varchar('sourceUrl', { length: 255 }).notNull(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       sharp:
         specifier: ^0.33.2
         version: 0.33.2
+      simple-hue-picker:
+        specifier: ^0.2.0
+        version: 0.2.0(react@18.2.0)
       superjson:
         specifier: ^2.2.1
         version: 2.2.1
@@ -29679,6 +29682,17 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /simple-hue-picker@0.2.0(react@18.2.0):
+    resolution: {integrity: sha512-uEEtnAwqe/XHzqx9UUYpRkNyeJ21S8u2hxDmf+yZh3ioPT3k1hcsaYnwsmTrg+Ex5f9V80fjHdf6+ddiO4AiNA==}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+    dependencies:
+      react: 18.2.0
+    dev: false
 
   /simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}


### PR DESCRIPTION
- added simple-hue-picker to workspace settings (used across landing pages & cart for now)
- we don't send the whole workspace for each form now, just id + what's being updated.
- updated fmPage.handle to cascade on update