### PR TITLE
add ViewContent with content_type for fm pages

### DIFF
--- a/packages/lib/server/routes/event/event.fns.ts
+++ b/packages/lib/server/routes/event/event.fns.ts
@@ -955,6 +955,14 @@ function getMetaEventFromFmEvent({
 						platform: fmLink?.platform,
 					},
 				},
+				{
+					eventName: 'ViewContent',
+					customData: {
+						content_type: 'barely.fm/linkClick',
+						fmId: fmPage.id,
+						platform: fmLink?.platform,
+					},
+				},
 			];
 		default:
 			return null;


### PR DESCRIPTION
Too hard to get some clients to approve the custom barely.fm/linkClick event