### PR TITLE
fix: resolve login redirect loop and improve CI/CD db:push handling

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -118,11 +118,31 @@ jobs:
           echo "DATABASE_URL=$DATABASE_URL" >> .env
           echo "DATABASE_POOL_URL=$DATABASE_POOL_URL" >> .env
 
-          output=$(pnpm db:push)
+          # Run db:push with timeout to prevent hanging on interactive prompts
+          output=$(timeout 60s bash -c 'echo "n" | pnpm db:push' 2>&1) || {
+            echo "ERROR: db:push timed out or failed - likely requires interactive input"
+            echo "output: $output"
+            echo "Please run 'pnpm db:push' locally to handle any schema ambiguities"
+            exit 1
+          }
+          
           echo "output: $output"
-          if [[ $output == *"error:"* || $output == *"severity: 'ERROR'"* ]]; then
-            echo "Unhandled error: $output" && exit 1
+          
+          # Check for successful completion
+          if [[ $output != *"[✓] Changes applied"* ]] && [[ $output != *"No changes detected"* ]]; then
+            echo "ERROR: db:push did not complete successfully"
+            echo "Expected to see '[✓] Changes applied' or 'No changes detected' in output"
+            
+            # Check for known interactive prompt patterns
+            if [[ $output == *"?"* ]] || [[ $output == *"›"* ]] || [[ $output == *"❯"* ]]; then
+              echo "Detected interactive prompt - manual intervention required"
+              echo "Please run 'pnpm db:push' locally to handle schema changes"
+            fi
+            
+            exit 1
           fi
+          
+          echo "db:push completed successfully"
 
       # Using Vercel as our secret store for the DATABASE_URL and DATABASE_POOL_URL
       # -- to my knowledge, using an external store is the only way to pass secrets between Github Actions jobs?

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -117,17 +117,21 @@ jobs:
           
           echo "output: $output"
           
-          # Check for errors in output
-          if [[ $output == *"error:"* || $output == *"severity: 'ERROR'"* ]]; then
-            echo "Unhandled error: $output" && exit 1
-          fi
-          
-          # Check for interactive prompts that indicate schema ambiguities
-          if [[ $output == *"Is"*"column"*"created or renamed"* || $output == *"create column"* || $output == *"rename column"* ]]; then
-            echo "ERROR: db:push requires manual intervention for schema changes"
-            echo "Detected interactive prompt in output"
+          # Check for successful completion
+          if [[ $output != *"[✓] Changes applied"* ]] && [[ $output != *"No changes detected"* ]]; then
+            echo "ERROR: db:push did not complete successfully"
+            echo "Expected to see '[✓] Changes applied' or 'No changes detected' in output"
+            
+            # Check for known interactive prompt patterns
+            if [[ $output == *"?"* ]] || [[ $output == *"›"* ]] || [[ $output == *"❯"* ]]; then
+              echo "Detected interactive prompt - manual intervention required"
+              echo "Please run 'pnpm db:push' locally to handle schema changes"
+            fi
+            
             exit 1
           fi
+          
+          echo "db:push completed successfully"
 
   # 📱 DEPLOY APPS -- PROD (Not Aliasing to Production Yet) #
   deploy-app:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -107,10 +107,26 @@ jobs:
           echo DATABASE_URL=$(neonctl cs ${{ secrets.NEON_MAIN_BRANCH_NAME }} --project-id ${{ secrets.NEON_PROJECT_ID }} --role-name ${{ secrets.PG_USERNAME }} --database-name ${{ secrets.PG_DATABASE }} --api-key ${{ secrets.NEON_API_KEY }}) >> .env
           echo DIRECT_DATABASE_URL=$(neonctl cs ${{ secrets.NEON_MAIN_BRANCH_NAME }} --project-id ${{ secrets.NEON_PROJECT_ID }} --role-name ${{ secrets.PG_USERNAME }} --database-name ${{ secrets.PG_DATABASE }} --api-key ${{ secrets.NEON_API_KEY }}) >> .env
 
-          output=$(pnpm db:push)
+          # Run db:push with timeout to prevent hanging on interactive prompts
+          output=$(timeout 60s bash -c 'echo "n" | pnpm db:push' 2>&1) || {
+            echo "ERROR: db:push timed out or failed - likely requires interactive input"
+            echo "output: $output"
+            echo "Please run 'pnpm db:push' locally to handle any schema ambiguities"
+            exit 1
+          }
+          
           echo "output: $output"
+          
+          # Check for errors in output
           if [[ $output == *"error:"* || $output == *"severity: 'ERROR'"* ]]; then
             echo "Unhandled error: $output" && exit 1
+          fi
+          
+          # Check for interactive prompts that indicate schema ambiguities
+          if [[ $output == *"Is"*"column"*"created or renamed"* || $output == *"create column"* || $output == *"rename column"* ]]; then
+            echo "ERROR: db:push requires manual intervention for schema changes"
+            echo "Detected interactive prompt in output"
+            exit 1
           fi
 
   # 📱 DEPLOY APPS -- PROD (Not Aliasing to Production Yet) #

--- a/apps/app/src/app/(auth)/handle-logged-in-on-auth-page.ts
+++ b/apps/app/src/app/(auth)/handle-logged-in-on-auth-page.ts
@@ -21,5 +21,6 @@ export async function handleLoggedInOnAuthPage(props?: { callbackUrl?: string })
 		return;
 	}
 
-	return redirect('/');
+	// Don't redirect to root if no session - this prevents redirect loops
+	return;
 }


### PR DESCRIPTION
## Summary
- Fixed infinite redirect loop between `/` and `/login` pages when user is not authenticated
- Improved CI/CD workflow to properly handle interactive db:push prompts by failing explicitly rather than hanging

## Problem
1. **Login redirect loop**: When unauthenticated users visited `/login`, they were redirected to `/` which then redirected back to `/login`, creating an infinite loop
2. **CI/CD db:push hanging**: The production workflow would hang indefinitely when `pnpm db:push` required interactive input for schema ambiguities, making it appear successful when it actually wasn't

## Solution
1. **Remove redirect to root**: Modified `handleLoggedInOnAuthPage()` to return early instead of redirecting to `/` when no session exists
2. **Add timeout and detection**: Updated CI/CD workflow to:
   - Use 60-second timeout to prevent hanging
   - Detect interactive prompts in output
   - Fail with clear error message instructing developers to run db:push locally

## Test plan
- [x] Verified login page loads without redirect loop
- [x] Tested authentication flow still works correctly
- [ ] CI/CD will fail on this PR (expected) since db schema changes need to be pushed manually first

🤖 Generated with [Claude Code](https://claude.ai/code)