### PR TITLE
fix: update vip download email from name and preview text

### DIFF
--- a/packages/email/src/templates/vip/vip-download.tsx
+++ b/packages/email/src/templates/vip/vip-download.tsx
@@ -34,7 +34,7 @@ export function VipDownloadEmailTemplate({
 	emailBody,
 	expiresIn = '24 hours',
 }: VipDownloadEmailProps) {
-	const previewText = `Download ${swapName} from ${artistName}`;
+	const previewText = "Here's your download!";
 
 	return (
 		<Html>

--- a/packages/lib/src/trpc/routes/vip-swap-render.route.ts
+++ b/packages/lib/src/trpc/routes/vip-swap-render.route.ts
@@ -271,7 +271,10 @@ export const vipSwapRenderRoute = {
 			// Send email first - if it fails, we won't create the access log
 			await sendEmail({
 				from: 'downloads@hello.barely.vip',
-				fromFriendlyName: vipSwap.emailFromName ?? workspace?.name ?? 'Barely.vip',
+				fromFriendlyName:
+					workspace?.name && workspace.name.length > 0 ?
+						workspace.name
+					:	(workspace?.handle ?? 'Barely.vip'),
 				replyTo: workspace?.vipSupportEmail ?? undefined,
 				to: email,
 				subject:


### PR DESCRIPTION
Fixes #331

## Summary

- Update VIP download email "from" name to use workspace.name if length > 0, otherwise workspace.handle
- Change preview text to "Here's your download!"

## Changes

1. Updated preview text in `vip-download.tsx`
2. Updated `fromFriendlyName` logic in `vip-swap-render.route.ts`

Generated with [Claude Code](https://claude.ai/code)