### PR TITLE
fix: skip error logging for root paths in fm, page, and vip middleware

### DIFF
--- a/apps/fm/src/middleware.tsx
+++ b/apps/fm/src/middleware.tsx
@@ -16,14 +16,11 @@ export async function middleware(req: NextRequest) {
 		const res = NextResponse.next();
 
 		if (!handle || !key) {
-			// Don't log errors for root path - it's expected to not have handle/key
-			if (pathname !== '/') {
-				await log({
-					message: `missing handle or key for barely, ${handle}, ${key}`,
-					type: 'errors',
-					location: 'fm/middleware.tsx',
-				});
-			}
+			await log({
+				message: `missing handle or key for barely, ${handle}, ${key}`,
+				type: 'errors',
+				location: 'fm/middleware.tsx',
+			});
 		}
 
 		await setVisitorCookies({ req, res, handle, key, app: 'fm' });
@@ -68,6 +65,6 @@ export const config = {
 		 * - sitemap (sitemap file)
 		 * - site.webmanifest (site.webmanifest file)
 		 */
-		'/((?!api|_next|_static|.well-known|favicon|logos|sitemap|site.webmanifest).*)',
+		'/((?!api|_next|_static|.well-known|favicon|logos|sitemap|site.webmanifest|robots.txt|$).*)',
 	],
 };

--- a/apps/fm/src/middleware.tsx
+++ b/apps/fm/src/middleware.tsx
@@ -16,11 +16,14 @@ export async function middleware(req: NextRequest) {
 		const res = NextResponse.next();
 
 		if (!handle || !key) {
-			await log({
-				message: `missing handle or key for barely, ${handle}, ${key}`,
-				type: 'errors',
-				location: 'fm/middleware.tsx',
-			});
+			// Don't log errors for root path - it's expected to not have handle/key
+			if (pathname !== '/') {
+				await log({
+					message: `missing handle or key for barely, ${handle}, ${key}`,
+					type: 'errors',
+					location: 'fm/middleware.tsx',
+				});
+			}
 		}
 
 		await setVisitorCookies({ req, res, handle, key, app: 'fm' });

--- a/apps/page/src/middleware.tsx
+++ b/apps/page/src/middleware.tsx
@@ -21,11 +21,14 @@ export async function middleware(req: NextRequest) {
 		const res = NextResponse.next();
 
 		if (!handle || !key) {
-			await log({
-				message: `missing handle or key for barely, ${handle}, ${key}`,
-				type: 'errors',
-				location: 'page/middleware.tsx',
-			});
+			// Don't log errors for root path - it's expected to not have handle/key
+			if (pathname !== '/') {
+				await log({
+					message: `missing handle or key for barely, ${handle}, ${key}`,
+					type: 'errors',
+					location: 'page/middleware.tsx',
+				});
+			}
 		}
 
 		await setVisitorCookies({ req, res, handle, key, app: 'page' });

--- a/apps/page/src/middleware.tsx
+++ b/apps/page/src/middleware.tsx
@@ -21,14 +21,11 @@ export async function middleware(req: NextRequest) {
 		const res = NextResponse.next();
 
 		if (!handle || !key) {
-			// Don't log errors for root path - it's expected to not have handle/key
-			if (pathname !== '/') {
-				await log({
-					message: `missing handle or key for barely, ${handle}, ${key}`,
-					type: 'errors',
-					location: 'page/middleware.tsx',
-				});
-			}
+			await log({
+				message: `missing handle or key for barely, ${handle}, ${key}`,
+				type: 'errors',
+				location: 'page/middleware.tsx',
+			});
 		}
 
 		await setVisitorCookies({ req, res, handle, key, app: 'page' });
@@ -69,6 +66,6 @@ export const config = {
 		 * - sitemap (sitemap file)
 		 * - site.webmanifest (site.webmanifest file)
 		 */
-		'/((?!api|_next|_static|.well-known|favicon|logos|sitemap|site.webmanifest).*)',
+		'/((?!api|_next|_static|.well-known|favicon|logos|sitemap|site.webmanifest|robots.txt|$).*)',
 	],
 };

--- a/apps/vip/src/middleware.ts
+++ b/apps/vip/src/middleware.ts
@@ -15,14 +15,11 @@ export async function middleware(req: NextRequest) {
 	const res = NextResponse.next();
 
 	if (!handle || !key) {
-		// Don't log errors for root path - it's expected to not have handle/key
-		if (pathname !== '/') {
-			await log({
-				message: `missing handle or key for vip, ${handle}, ${key}`,
-				type: 'errors',
-				location: 'vip/middleware.tsx',
-			});
-		}
+		await log({
+			message: `missing handle or key for vip, ${handle}, ${key}`,
+			type: 'errors',
+			location: 'vip/middleware.ts',
+		});
 		// Still set visitor cookies even if handle/key missing to track anonymous visits
 		await setVisitorCookies({ req, res, handle: null, key: null, app: 'vip' });
 		return res;
@@ -47,6 +44,6 @@ export const config = {
 		 * - sitemap (sitemap file)
 		 * - site.webmanifest (site.webmanifest file)
 		 */
-		'/((?!api|_next|_static|.well-known|favicon|logos|sitemap|site.webmanifest).*)',
+		'/((?!api|_next|_static|.well-known|favicon|logos|sitemap|site.webmanifest|robots.txt|$).*)',
 	],
 };

--- a/apps/vip/src/middleware.ts
+++ b/apps/vip/src/middleware.ts
@@ -15,11 +15,14 @@ export async function middleware(req: NextRequest) {
 	const res = NextResponse.next();
 
 	if (!handle || !key) {
-		await log({
-			message: `missing handle or key for vip, ${handle}, ${key}`,
-			type: 'errors',
-			location: 'vip/middleware.tsx',
-		});
+		// Don't log errors for root path - it's expected to not have handle/key
+		if (pathname !== '/') {
+			await log({
+				message: `missing handle or key for vip, ${handle}, ${key}`,
+				type: 'errors',
+				location: 'vip/middleware.tsx',
+			});
+		}
 		// Still set visitor cookies even if handle/key missing to track anonymous visits
 		await setVisitorCookies({ req, res, handle: null, key: null, app: 'vip' });
 		return res;


### PR DESCRIPTION
Fixes #338

## Summary
Fixed middleware errors for root paths by skipping error logging when pathname is `/`.

## Changes
- Modified middleware in vip, fm, and page apps to check if pathname is `/` before logging errors
- Root paths no longer log "missing handle or key" errors
- Visitor cookies are still set for all paths including root
- Other paths continue to log errors when handle/key are missing

This complements the previous fix that added `robots.txt` to the excluded paths.

Generated with [Claude Code](https://claude.ai/code)