### PR TITLE
fix: handle empty string in currency input to prevent NaN values

### DIFF
--- a/packages/ui/src/elements/currency-input.tsx
+++ b/packages/ui/src/elements/currency-input.tsx
@@ -54,10 +54,13 @@ export const CurrencyInput = React.forwardRef<HTMLInputElement, CurrencyInputPro
 			console.log('values', values);
 			setFocusedValue(value ?? '');
 
-			const valueInUnits =
-				!values?.float ? 0
-				: outputUnit === 'minor' ? values.float * 100
-				: values.float;
+			// Handle empty string case
+			if (!value || value === '' || !values?.float) {
+				await onValueChange?.(0);
+				return;
+			}
+
+			const valueInUnits = outputUnit === 'minor' ? values.float * 100 : values.float;
 
 			if (!isNaN(valueInUnits)) {
 				await onValueChange?.(

--- a/packages/utils/src/currency.ts
+++ b/packages/utils/src/currency.ts
@@ -23,7 +23,18 @@ export function handleCurrencyMinorStringOrMajorNumber(amount: string | number) 
 		return amount;
 	}
 
+	// Handle empty string case
+	if (amount === '') {
+		return 0;
+	}
+
 	const sanitizedAmount =
 		typeof amount === 'string' ? parseFloat(amount.replace(/^[$£€¥]/, '')) : amount;
+
+	// Handle NaN case (e.g., when parseFloat fails)
+	if (isNaN(sanitizedAmount)) {
+		return 0;
+	}
+
 	return sanitizedAmount * 100;
 }


### PR DESCRIPTION
Fixes #350

## Summary

Fixed the NaN issue that occurred when the currency field had an empty string value.

## Changes

- Updated `handleCurrencyMinorStringOrMajorNumber` helper to return 0 for empty strings
- Fixed `CurrencyInput` component to handle empty/null values properly
- Prevents NaN from appearing in invoice line items when currency field is empty

Generated with [Claude Code](https://claude.ai/code)