### PR TITLE
fix: use 'Barely Invoice' as consistent friendly name for all invoice emails

### DIFF
--- a/packages/lib/src/functions/invoice-email.fns.ts
+++ b/packages/lib/src/functions/invoice-email.fns.ts
@@ -89,7 +89,7 @@ export async function sendInvoiceEmail({ invoice, pdfBase64 }: SendInvoiceEmailP
 	// Send email
 	const result = await sendEmail({
 		from: 'hello@pay.barelyinvoice.com',
-		fromFriendlyName: workspace.name,
+		fromFriendlyName: 'Barely Invoice',
 		to: client.email,
 		replyTo,
 		bcc: [replyTo, 'invoices@barely.ai'].filter(email => email.length > 0),
@@ -200,7 +200,7 @@ export async function sendInvoiceReminderEmail({
 
 	const result = await sendEmail({
 		from: 'hello@pay.barelyinvoice.com',
-		fromFriendlyName: workspace.name,
+		fromFriendlyName: 'Barely Invoice',
 		to: client.email,
 		replyTo,
 		bcc: [
@@ -311,7 +311,7 @@ export async function sendInvoicePaymentReceivedEmail({
 
 	const result = await sendEmail({
 		from: 'hello@pay.barelyinvoice.com',
-		fromFriendlyName: workspace.name,
+		fromFriendlyName: 'Barely Invoice',
 		to: client.email,
 		replyTo,
 		bcc: [replyTo, 'invoices@barely.ai'].filter(email => email.length > 0),


### PR DESCRIPTION
Fixes #367

## Summary

Updates all invoice email sending functions to use "Barely Invoice" as the consistent friendly name instead of using the workspace name. This ensures better spam filtering and consistent sender recognition.

## Changes

- Updated `sendInvoiceEmail` to use 'Barely Invoice'
- Updated `sendInvoiceReminderEmail` to use 'Barely Invoice'
- Updated `sendInvoicePaymentReceivedEmail` to use 'Barely Invoice'

The workspace name is still preserved in the email subject lines and email content for clarity.

Generated with [Claude Code](https://claude.ai/code)