### PR TITLE
fix: update bio URLs to use query params instead of path params

### DIFF
--- a/apps/app/src/app/[handle]/bios/_components/all-bios.tsx
+++ b/apps/app/src/app/[handle]/bios/_components/all-bios.tsx
@@ -32,7 +32,7 @@ export function AllBios() {
 					// Navigate to bio blocks editor
 					const bio = items.find(b => b.id === key);
 					if (bio) {
-						router.push(`/${bio.handle}/bios/${bio.key}/blocks`);
+						router.push(`/${bio.handle}/bios/blocks?bioKey=${bio.key}`);
 					}
 				}}
 				items={items}
@@ -77,7 +77,9 @@ function BioPageCard({
 			id={bio.id}
 			key={bio.id}
 			textValue={bio.key}
-			setShowUpdateModal={() => router.push(`/${bio.handle}/bios/${bio.key}/blocks`)}
+			setShowUpdateModal={() =>
+				router.push(`/${bio.handle}/bios/blocks?bioKey=${bio.key}`)
+			}
 			setShowArchiveModal={isHomeBio ? undefined : setShowArchiveModal}
 			setShowDeleteModal={isHomeBio ? undefined : setShowDeleteModal}
 			title={bio.key}
@@ -104,7 +106,7 @@ function BioPageCard({
 			// 	},
 			// ]}
 			onAction={() => {
-				router.push(`/${bio.handle}/bios/${bio.key}/blocks`);
+				router.push(`/${bio.handle}/bios/blocks?bioKey=${bio.key}`);
 			}}
 		/>
 	);

--- a/apps/app/src/app/[handle]/bios/_components/create-bio-modal.tsx
+++ b/apps/app/src/app/[handle]/bios/_components/create-bio-modal.tsx
@@ -48,7 +48,7 @@ export function CreateBioModal() {
 				await setShowCreateModal(false);
 				form.reset();
 				// Navigate to the new bio's blocks page
-				router.push(`/${handle}/bios/${data.key}/blocks`);
+				router.push(`/${handle}/bios/blocks?bioKey=${data.key}`);
 			},
 			onError: error => {
 				console.error('Failed to create bio:', error);


### PR DESCRIPTION
Fixes #368

## Summary

Updated all bio URLs in the app to use the new format where `bioKey` is a query parameter instead of a path parameter.

## Changes

- Updated 3 instances in `all-bios.tsx`
- Updated 1 instance in `create-bio-modal.tsx`
- `app-bio-render.tsx` was already using the correct format

## Before
```typescript
router.push(`/${bio.handle}/bios/${bio.key}/blocks`);
```

## After
```typescript
router.push(`/${bio.handle}/bios/blocks?bioKey=${bio.key}`);
```

Generated with [Claude Code](https://claude.ai/code)