### PR TITLE
fix: invoice overdue trigger firing a day early

### DIFF
--- a/packages/lib/src/trigger/overdue-invoices.trigger.ts
+++ b/packages/lib/src/trigger/overdue-invoices.trigger.ts
@@ -22,10 +22,14 @@ export const overdueInvoicesTrigger = schedules.task({
 			const db = dbPool(pool);
 
 			// Find all invoices that are past due date and not yet paid
+			// An invoice is overdue if we're past the END of the due date (not just at the due date)
+			const today = new Date();
+			today.setHours(0, 0, 0, 0); // Start of today
+
 			const overdueInvoices = await db.query.Invoices.findMany({
 				where: and(
 					or(eq(Invoices.status, 'sent'), eq(Invoices.status, 'viewed')),
-					lt(Invoices.dueDate, new Date()),
+					lt(Invoices.dueDate, today), // Due date is before today (not including today)
 				),
 				with: {
 					client: true,


### PR DESCRIPTION
Fixes #371

## Description
Updated the overdue invoice check to only mark invoices as overdue after the due date has fully passed. Previously, invoices were marked overdue at midnight on the due date. Now they are only marked overdue starting the day after the due date.

## Changes
- Modified date comparison in overdue invoices trigger to use start of today
- Added explanatory comment about the logic
- Due dates are now treated as inclusive (invoice due on Sept 15 becomes overdue on Sept 16)

Generated with [Claude Code](https://claude.ai/code)