### PR TITLE
fix: handle journey params properly in VIP event logging

### DIFF
--- a/packages/lib/src/functions/event.fns.ts
+++ b/packages/lib/src/functions/event.fns.ts
@@ -1382,18 +1382,32 @@ export async function recordVipEvent({
 
 	// report event to tinybird
 	try {
+		// Extract journey info from visitor with proper defaults for VIP events
+		const journeyId = visitor?.journeyId ?? visitor?.sessionId ?? newId('barelySession');
+		const journeyOrigin = visitor?.journeyOrigin ?? journeyId.split('_')[0] ?? 'vip';
+		const journeySource =
+			visitor?.journeySource ?? `vip:${vipSwap.handle}:${vipSwap.key}`;
+		const journeyStep = visitor?.journeyStep ? parseInt(visitor.journeyStep, 10) : 1;
+		const journeyPath = visitor?.journeyPath ?? [`vip:${vipSwap.handle}:${vipSwap.key}`];
+
 		await ingestVipEvent({
 			timestamp,
 			type,
 			workspaceId: vipSwap.workspaceId,
 			assetId: vipSwap.id,
-			sessionId: visitor?.sessionId ?? newId('barelySession'),
+			sessionId: journeyId,
 			...flattenVisitorForIngest(visitor),
 			href: sourceUrl,
 			reportedToMeta: metaPixel && metaRes.reported ? metaPixel.id : '',
 			vipSwapType: vipSwap.type,
 			vipDownloadToken: downloadToken ?? '',
 			vipEmailCaptured: emailCaptured ?? '',
+			// Journey tracking fields with proper defaults
+			journeyId,
+			journeyOrigin,
+			journeySource,
+			journeyStep,
+			journeyPath,
 		});
 	} catch (error) {
 		await log({


### PR DESCRIPTION
Fixes #373

## Summary

The VIP event logging was failing because journey parameters (journeyId, journeyOrigin, journeySource) were being passed as null values to Tinybird, which expected strings. Also, journeyStep was being passed as a string but the schema expects a number.

## Changes

- Add proper defaults for journey parameters when they're not provided in the visitor context
- Convert journeyStep to number to match schema requirement
- Initialize journeyPath array when not provided
- Pass journey fields explicitly to ingestVipEvent

This ensures VIP events are properly logged to Tinybird with valid journey tracking data.

🤖 Generated with [Claude Code](https://claude.ai/code)