### PR TITLE
feat: add custom title and description to bio pages

### DIFF
--- a/apps/app/src/app/[handle]/bios/_components/bio-blocks-page.tsx
+++ b/apps/app/src/app/[handle]/bios/_components/bio-blocks-page.tsx
@@ -743,6 +743,15 @@ export function BioBlocksPage({ bioKey }: { bioKey: string }) {
 		});
 	};
 
+	const { mutate } = useMutation(
+		trpc.bio.update.mutationOptions({
+			onSettled: async () => {
+				// Invalidate and refetch
+				await queryClient.invalidateQueries({ queryKey: bioQueryKey });
+			},
+		}),
+	);
+
 	const handleToggleBlock = async (blockId: string, enabled: boolean) => {
 		await updateBlockMutation.mutateAsync({
 			handle,
@@ -801,6 +810,51 @@ export function BioBlocksPage({ bioKey }: { bioKey: string }) {
 	// bio is guaranteed to be defined with useSuspenseQuery
 	return (
 		<div className='flex flex-col'>
+			{/* SEO Fields */}
+			<div className='mb-8 space-y-4'>
+				<div>
+					<Text variant='sm/semibold' className='mb-1'>
+						Page Title (SEO)
+					</Text>
+					<Input
+						value={bio.title ?? ''}
+						onChange={e => {
+							mutate({
+								handle,
+								id: bio.id,
+								title: e.target.value || null,
+							});
+						}}
+						placeholder={`${bio.handle} - Bio`}
+						className='w-full'
+					/>
+					<Text variant='xs/normal' className='mt-1 text-gray-500'>
+						Used for search results and browser tabs. Defaults to "{bio.handle} - Bio"
+					</Text>
+				</div>
+				<div>
+					<Text variant='sm/semibold' className='mb-1'>
+						Page Description (SEO)
+					</Text>
+					<textarea
+						value={bio.description ?? ''}
+						onChange={e => {
+							mutate({
+								handle,
+								id: bio.id,
+								description: e.target.value || null,
+							});
+						}}
+						placeholder={`Links and content from ${bio.handle}`}
+						className='w-full resize-none rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50'
+						rows={3}
+					/>
+					<Text variant='xs/normal' className='mt-1 text-gray-500'>
+						Used for search results. Defaults to "Links and content from {bio.handle}"
+					</Text>
+				</div>
+			</div>
+
 			{/* Add Block Button */}
 			<div className='mb-8'>
 				<Button

--- a/apps/bio/src/app/[...handleAndKey]/page.tsx
+++ b/apps/bio/src/app/[...handleAndKey]/page.tsx
@@ -144,8 +144,8 @@ export async function generateMetadata({ params }: BioRouteProps) {
 		const brandKit = await fetchBrandKit(handle);
 		const bio = await fetchBio(handle, key);
 
-		const title = `${bio.handle} - Bio`;
-		const description = `Links and content from ${bio.handle}`;
+		const title = bio.title || `${bio.handle} - Bio`;
+		const description = bio.description || `Links and content from ${bio.handle}`;
 		const imageUrl =
 			brandKit.avatarS3Key ? s3Loader({ s3Key: brandKit.avatarS3Key, width: 400 }) : null;
 

--- a/packages/db/src/sql/bio.sql.ts
+++ b/packages/db/src/sql/bio.sql.ts
@@ -70,6 +70,10 @@ export const Bios = pgTable(
 		// email capture settings
 		emailCaptureEnabled: boolean('emailCaptureEnabled').default(false).notNull(),
 		emailCaptureIncentiveText: varchar('emailCaptureIncentiveText', { length: 255 }),
+
+		// SEO metadata
+		title: varchar('title', { length: 255 }),
+		description: text('description'),
 	},
 	bio => ({
 		workspace: index('Bios_workspace_idx').on(bio.workspaceId),

--- a/packages/validators/src/schemas/bio.schema.ts
+++ b/packages/validators/src/schemas/bio.schema.ts
@@ -32,12 +32,28 @@ export const createBioSchema = insertBioSchema.omit({
 	deletedAt: true,
 });
 
-export const updateBioSchema = insertBioSchema.partial().required({ id: true }).omit({
-	workspaceId: true,
-	createdAt: true,
-	updatedAt: true,
-	deletedAt: true,
-});
+export const updateBioSchema = insertBioSchema
+	.partial()
+	.required({ id: true })
+	.omit({
+		workspaceId: true,
+		createdAt: true,
+		updatedAt: true,
+		deletedAt: true,
+	})
+	.extend({
+		// Extend with validation for SEO fields
+		title: z
+			.string()
+			.max(255, 'Title must be less than 255 characters')
+			.optional()
+			.nullable(),
+		description: z
+			.string()
+			.max(1000, 'Description must be less than 1000 characters')
+			.optional()
+			.nullable(),
+	});
 
 export const publicBioSchema = z.object({
 	handle: z.string(),
@@ -53,6 +69,8 @@ export const publicBioSchema = z.object({
 	barelyBranding: z.boolean(),
 	emailCaptureEnabled: z.boolean(),
 	emailCaptureIncentiveText: z.string().nullable(),
+	title: z.string().nullable(),
+	description: z.string().nullable(),
 });
 
 export type InsertBio = z.infer<typeof insertBioSchema>;


### PR DESCRIPTION
Fixes #388

## Summary

This PR adds the ability to set custom title and description for bio pages to improve SEO.

## Changes

- Added `title` and `description` fields to the Bios database table
- Updated validators to support SEO metadata fields with proper validation
- Added UI inputs for title/description in bio-blocks-page above the "Add block" button
- Updated generateMetadata to use custom values when available

## Notes

- Title has a 255 character limit
- Description has a 1000 character limit
- Both fields are optional and have sensible defaults
- Changes auto-save as the user types

Generated with [Claude Code](https://claude.ai/code)