### PR TITLE
fix: correct CTA link URL generation for bio and cart targets

### DIFF
--- a/packages/ui/src/bio/blocks/cta-button.tsx
+++ b/packages/ui/src/bio/blocks/cta-button.tsx
@@ -53,14 +53,17 @@ export function CtaButton({ block, blockIndex, blockType, className }: CtaButton
 		} else if (block.targetBio) {
 			baseHref = getAbsoluteUrl(
 				'bio',
-				`/${block.targetBio.handle}/bio/${block.targetBio.key}`,
+				`/${block.targetBio.handle}/${block.targetBio.key}`,
 			);
 		} else if (block.targetFm) {
 			// FM routes not implemented yet
 			baseHref = getAbsoluteUrl('fm', `/${block.targetFm.handle}/${block.targetFm.key}`);
 		} else if (block.targetCartFunnel) {
 			// Cart checkout URL logic
-			baseHref = getAbsoluteUrl('cart', `/${block.targetCartFunnel.key}`);
+			baseHref = getAbsoluteUrl(
+				'cart',
+				`${block.targetCartFunnel.handle}/${block.targetCartFunnel.key}/checkout`,
+			);
 		} else if (block.targetLink) {
 			// Short link redirect
 			baseHref = block.targetLink.url;

--- a/packages/ui/src/bio/blocks/two-panel-block-shared.tsx
+++ b/packages/ui/src/bio/blocks/two-panel-block-shared.tsx
@@ -139,14 +139,17 @@ export function TwoPanelBlockShared({
 		} else if (block.targetBio) {
 			baseHref = getAbsoluteUrl(
 				'bio',
-				`/${block.targetBio.handle}/bio/${block.targetBio.key}`,
+				`/${block.targetBio.handle}/${block.targetBio.key}`,
 			);
 		} else if (block.targetFm) {
 			// FM routes not implemented yet
 			baseHref = getAbsoluteUrl('fm', `/${block.targetFm.handle}/${block.targetFm.key}`);
 		} else if (block.targetCartFunnel) {
 			// Cart checkout URL logic would go here
-			baseHref = getAbsoluteUrl('cart', `/${block.targetCartFunnel.key}`);
+			baseHref = getAbsoluteUrl(
+				'cart',
+				`${block.targetCartFunnel.handle}/${block.targetCartFunnel.key}/checkout`,
+			);
 		} else if (block.targetLink) {
 			// Short link redirect
 			baseHref = block.targetLink.url;


### PR DESCRIPTION
## Summary
- Fixed CTA link generation to use correct URL patterns for bio and cart targets
- Simplified bio URLs by removing redundant `/bio` segment
- Added missing handle and `/checkout` path to cart funnel URLs

## Changes
- **Bio links**: Changed from `/{handle}/bio/{key}` to `/{handle}/{key}` for cleaner URLs
- **Cart links**: Changed from `/{key}` to `{handle}/{key}/checkout` for proper scoping and explicit checkout intent
- Applied changes consistently in both `cta-button.tsx` and `two-panel-block-shared.tsx`

## Test plan
- [ ] Verify bio CTA links navigate to correct simplified URLs
- [ ] Verify cart funnel CTA links include handle and checkout path
- [ ] Test CTA generation in both standard buttons and two-panel blocks
- [ ] Ensure all other CTA target types (external URL, targetLink) still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)