### PR TITLE
feat: conditional bio card width based on two-panel blocks

### DIFF
--- a/apps/bio/src/app/[...handleAndKey]/bio-bio-render.tsx
+++ b/apps/bio/src/app/[...handleAndKey]/bio-bio-render.tsx
@@ -206,7 +206,7 @@ export function BioBioRender({
 	const bgColor = colors[bgColorIndex] ?? brandKit.color1;
 
 	// Lighten the background color slightly for subtle contrast
-	const backgroundColor = modifyOklch(bgColor, { alpha: 0.7 });
+	const backgroundColor = modifyOklch(bgColor, { alpha: 0.75 });
 
 	return (
 		<div
@@ -217,7 +217,7 @@ export function BioBioRender({
 		>
 			<div
 				className={`mx-auto px-0 py-0 sm:px-4 sm:py-12 ${
-					bio.hasTwoPanel ? 'max-w-[750px]' : 'max-w-xl'
+					bio.hasTwoPanel ? 'max-w-[800px]' : 'max-w-[575px]'
 				}`}
 			>
 				<BioBrandKitProvider brandKit={brandKit}>

--- a/apps/bio/src/app/[...handleAndKey]/bio-bio-render.tsx
+++ b/apps/bio/src/app/[...handleAndKey]/bio-bio-render.tsx
@@ -215,7 +215,11 @@ export function BioBioRender({
 				backgroundColor,
 			}}
 		>
-			<div className='mx-auto max-w-[725px] px-0 py-0 sm:px-4 sm:py-12'>
+			<div
+				className={`mx-auto px-0 py-0 sm:px-4 sm:py-12 ${
+					bio.hasTwoPanel ? 'max-w-[750px]' : 'max-w-xl'
+				}`}
+			>
 				<BioBrandKitProvider brandKit={brandKit}>
 					<BioBioProvider bio={bio} tracking={tracking}>
 						<BioLogVisit />

--- a/packages/db/src/sql/bio.sql.ts
+++ b/packages/db/src/sql/bio.sql.ts
@@ -71,6 +71,9 @@ export const Bios = pgTable(
 		emailCaptureEnabled: boolean('emailCaptureEnabled').default(false).notNull(),
 		emailCaptureIncentiveText: varchar('emailCaptureIncentiveText', { length: 255 }),
 
+		// layout settings
+		hasTwoPanel: boolean('hasTwoPanel').default(false).notNull(),
+
 		// SEO metadata
 		title: varchar('title', { length: 255 }),
 		description: text('description'),

--- a/packages/lib/src/trpc/routes/bio.route.ts
+++ b/packages/lib/src/trpc/routes/bio.route.ts
@@ -726,7 +726,10 @@ export const bioRoute = {
 			});
 
 			// If creating a twoPanel block, update the bio's hasTwoPanel flag
-			if (sanitizedBlockData.type === 'twoPanel' && sanitizedBlockData.enabled !== false) {
+			if (
+				sanitizedBlockData.type === 'twoPanel' &&
+				sanitizedBlockData.enabled !== false
+			) {
 				await dbPool(ctx.pool)
 					.update(Bios)
 					.set({ hasTwoPanel: true })
@@ -807,8 +810,10 @@ export const bioRoute = {
 			// Check if we need to update hasTwoPanel flag
 			// This handles enabling/disabling twoPanel blocks
 			if (updatedBlock && existingBlock) {
-				const wasEnabledTwoPanel = existingBlock.type === 'twoPanel' && existingBlock.enabled;
-				const isEnabledTwoPanel = updatedBlock.type === 'twoPanel' && updatedBlock.enabled;
+				const wasEnabledTwoPanel =
+					existingBlock.type === 'twoPanel' && existingBlock.enabled;
+				const isEnabledTwoPanel =
+					updatedBlock.type === 'twoPanel' && updatedBlock.enabled;
 
 				// If status changed, we need to check all blocks
 				if (wasEnabledTwoPanel !== isEnabledTwoPanel) {
@@ -870,7 +875,8 @@ export const bioRoute = {
 				),
 			});
 
-			const isDeletingTwoPanel = blockToDelete?.type === 'twoPanel' && blockToDelete?.enabled;
+			const isDeletingTwoPanel =
+				blockToDelete?.type === 'twoPanel' && blockToDelete.enabled;
 
 			// Remove the relationship
 			await dbPool(ctx.pool)

--- a/packages/ui/src/bio/bio-blocks-render.tsx
+++ b/packages/ui/src/bio/bio-blocks-render.tsx
@@ -52,7 +52,7 @@ export function BioBlocksRender({ blocks, targetBlockId }: BioBlocksRenderProps)
 	return (
 		<div
 			className={cn(
-				'flex flex-col gap-10 md:gap-12',
+				'flex flex-col gap-10 md:gap-14 lg:gap-16',
 				// brandKit.blockShadow && 'gap-4',
 				!isFullWidthButtons && '',
 				isFullWidthButtons && '', // No horizontal padding for full-width buttons

--- a/packages/ui/src/bio/blocks/cart-block.tsx
+++ b/packages/ui/src/bio/blocks/cart-block.tsx
@@ -77,55 +77,57 @@ export function CartBlock({ block, blockIndex }: CartBlockProps) {
 	// If styleAsButton is true, just render the button
 	if (block.styleAsButton) {
 		return (
-			<Button
-				href={checkoutUrl}
-				target='_blank'
-				variant='button'
-				look='primary'
-				size='lg'
-				fullWidth={true}
-				className={cn(
-					'bg-brandKit-block text-brandKit-block-text',
-					'hover:bg-brandKit-block/90',
-					getBrandKitOutlineClass(computedStyles.block.outline),
-					getBrandKitButtonRadiusClass(computedStyles.block.radius),
-					// Add animation class if specified
-					block.ctaAnimation &&
-						block.ctaAnimation !== 'none' &&
-						getAnimationClass(block.ctaAnimation),
-				)}
-				style={{
-					fontFamily: computedStyles.fonts.bodyFont,
-					boxShadow: computedStyles.block.shadow,
-				}}
-				onClick={async () => {
-					if (onTargetCartFunnelClick && block.targetCartFunnel) {
-						return await onTargetCartFunnelClick(block.targetCartFunnel, {
-							blockId: block.id,
-							blockType: 'cart',
-							blockIndex,
-							linkIndex: 0,
-						});
-					}
-				}}
-			>
-				<span className='flex items-center justify-center gap-2'>
-					{block.ctaIcon &&
-						block.ctaIcon !== 'none' &&
-						(() => {
-							const iconOption = BIO_BLOCK_ICON_OPTIONS.find(
-								opt => opt.value === block.ctaIcon,
-							);
+			<div className='mx-auto max-w-xl'>
+				<Button
+					href={checkoutUrl}
+					target='_blank'
+					variant='button'
+					look='primary'
+					size='lg'
+					fullWidth={true}
+					className={cn(
+						'bg-brandKit-block text-brandKit-block-text',
+						'hover:bg-brandKit-block/90',
+						getBrandKitOutlineClass(computedStyles.block.outline),
+						getBrandKitButtonRadiusClass(computedStyles.block.radius),
+						// Add animation class if specified
+						block.ctaAnimation &&
+							block.ctaAnimation !== 'none' &&
+							getAnimationClass(block.ctaAnimation),
+					)}
+					style={{
+						fontFamily: computedStyles.fonts.bodyFont,
+						boxShadow: computedStyles.block.shadow,
+					}}
+					onClick={async () => {
+						if (onTargetCartFunnelClick && block.targetCartFunnel) {
+							return await onTargetCartFunnelClick(block.targetCartFunnel, {
+								blockId: block.id,
+								blockType: 'cart',
+								blockIndex,
+								linkIndex: 0,
+							});
+						}
+					}}
+				>
+					<span className='flex items-center justify-center gap-2'>
+						{block.ctaIcon &&
+							block.ctaIcon !== 'none' &&
+							(() => {
+								const iconOption = BIO_BLOCK_ICON_OPTIONS.find(
+									opt => opt.value === block.ctaIcon,
+								);
 
-							const CtaIcon =
-								iconOption?.icon ? Icon[iconOption.icon as keyof typeof Icon] : null;
+								const CtaIcon =
+									iconOption?.icon ? Icon[iconOption.icon as keyof typeof Icon] : null;
 
-							if (!CtaIcon) return null;
-							return iconOption?.icon ? <CtaIcon className='h-4 w-4' /> : null;
-						})()}
-					{block.ctaText ?? 'Get Instant Access'}
-				</span>
-			</Button>
+								if (!CtaIcon) return null;
+								return iconOption?.icon ? <CtaIcon className='h-4 w-4' /> : null;
+							})()}
+						{block.ctaText ?? 'Get Instant Access'}
+					</span>
+				</Button>
+			</div>
 		);
 	}
 
@@ -133,7 +135,7 @@ export function CartBlock({ block, blockIndex }: CartBlockProps) {
 	return (
 		<div
 			className={cn(
-				'relative overflow-hidden',
+				'relative mx-auto max-w-xl overflow-hidden',
 				// Strong container with elevated appearance
 				'bg-brandKit-block/5 backdrop-blur-sm',
 				'border-brandKit-block/20 border-2',

--- a/packages/ui/src/bio/blocks/contact-form-block.tsx
+++ b/packages/ui/src/bio/blocks/contact-form-block.tsx
@@ -74,7 +74,7 @@ export function ContactFormBlock({ block }: ContactFormBlockProps) {
 	return (
 		<div
 			className={cn(
-				'w-full',
+				'mx-auto w-full max-w-xl',
 				// !isFullWidthButtons && 'px-4',
 				// isFullWidthButtons && 'px-0',
 			)}

--- a/packages/ui/src/bio/blocks/image-block.tsx
+++ b/packages/ui/src/bio/blocks/image-block.tsx
@@ -33,7 +33,7 @@ export function ImageBlock({ block }: ImageBlockProps) {
 
 	return (
 		<>
-			<div className='space-y-4'>
+			<div className='mx-auto max-w-xl space-y-4'>
 				{/* Block title and subtitle */}
 				{(block.title ?? block.subtitle) && (
 					<div className='space-y-1 text-center'>

--- a/packages/ui/src/bio/blocks/links-block.tsx
+++ b/packages/ui/src/bio/blocks/links-block.tsx
@@ -29,7 +29,7 @@ export function LinksBlock({ block, blockIndex }: LinksBlockProps) {
 	const showTitle = block.title && block.title.trim() !== '';
 	const showSubtitle = block.subtitle && block.subtitle.trim() !== '';
 	return (
-		<div className='space-y-3'>
+		<div className='mx-auto max-w-xl space-y-3'>
 			{/* Render block title and subtitle if they exist */}
 			{(showTitle ?? showSubtitle) && (
 				<div

--- a/packages/ui/src/bio/blocks/markdown-block.tsx
+++ b/packages/ui/src/bio/blocks/markdown-block.tsx
@@ -51,7 +51,7 @@ export function MarkdownBlock({ block, blockIndex }: MarkdownBlockProps) {
 
 	return (
 		<div
-			className={cn('space-y-4', isPreview && 'cursor-pointer')}
+			className={cn('mx-auto max-w-xl space-y-4', isPreview && 'cursor-pointer')}
 			onClick={handleBlockClick}
 		>
 			<MarkdownBlockHeader


### PR DESCRIPTION
## Summary
- Implements conditional bio card width that expands from 640px (max-w-xl) to 750px when the bio contains two-panel blocks
- Adds `hasTwoPanel` column to track presence of two-panel blocks at the database level for performance
- Automatically maintains the `hasTwoPanel` flag when blocks are created, updated, or deleted

## Changes
- **Database**: Added `hasTwoPanel` boolean column to Bios table (defaults to false)
- **API**: Updated bio.route.ts to maintain `hasTwoPanel` flag:
  - Sets to true when creating enabled twoPanel blocks
  - Recalculates when updating block enabled state
  - Checks remaining blocks when deleting twoPanel blocks
- **UI**: BioBioRender now uses conditional width based on `hasTwoPanel` flag

## Test plan
- [ ] Create a bio without two-panel blocks - verify width is max-w-xl (640px)
- [ ] Add a two-panel block - verify width expands to 750px
- [ ] Disable the two-panel block - verify width returns to 640px
- [ ] Re-enable the block - verify width expands again
- [ ] Delete the two-panel block - verify width returns to 640px
- [ ] Add multiple two-panel blocks and delete one - verify width remains at 750px
- [ ] Run `pnpm db:push` to apply schema changes

## Notes
- Existing bios won't have the correct `hasTwoPanel` value until they modify blocks, but the width difference is minor (640px vs 750px) so this is acceptable
- The database approach was chosen over dynamic computation for better performance

🤖 Generated with [Claude Code](https://claude.ai/code)