### PR TITLE
feat: auto-select new client on create invoice page

### DIFF
--- a/apps/app/src/app/[handle]/invoices/_components/create-invoice-multi-step-form.tsx
+++ b/apps/app/src/app/[handle]/invoices/_components/create-invoice-multi-step-form.tsx
@@ -775,11 +775,29 @@ export function CreateInvoiceMultiStepForm() {
 		}
 	};
 
-	// Refetch clients when modal closes
-	const handleClientModalClose = useCallback(async () => {
+	// Handle client modal close and auto-select created client
+	const handleClientModalClose = useCallback(async (createdClient?: { id: string; name: string; email: string }) => {
 		await refetchClients();
 		void setShowCreateModal(false);
-	}, [refetchClients, setShowCreateModal]);
+		
+		// Auto-select the newly created client if provided
+		if (createdClient) {
+			setSelectedClientId(createdClient.id);
+			
+			// Set invoice number if it's empty
+			if (
+				!detailsForm.getValues('invoiceNumber') ||
+				detailsForm.getValues('invoiceNumber') === ''
+			) {
+				if (nextInvoiceNumber) {
+					detailsForm.setValue('invoiceNumber', nextInvoiceNumber);
+				}
+			}
+			
+			// Move to the next step (details)
+			setCurrentStep('details');
+		}
+	}, [refetchClients, setShowCreateModal, detailsForm, nextInvoiceNumber]);
 
 	return (
 		<>

--- a/apps/app/src/app/[handle]/invoices/_components/create-or-update-client-modal.tsx
+++ b/apps/app/src/app/[handle]/invoices/_components/create-or-update-client-modal.tsx
@@ -25,7 +25,7 @@ export function CreateOrUpdateClientModal({
 	onClose,
 }: {
 	mode: 'create' | 'update';
-	onClose?: () => void | Promise<void>;
+	onClose?: (createdClient?: { id: string; name: string; email: string }) => void | Promise<void>;
 }) {
 	const params = useParams();
 	const handle = params.handle as string;
@@ -45,8 +45,11 @@ export function CreateOrUpdateClientModal({
 
 	const { mutateAsync: createClient } = useMutation(
 		trpc.invoiceClient.create.mutationOptions({
-			onSuccess: async () => {
+			onSuccess: async (data) => {
 				await setShowModal(false);
+				if (onClose && mode === 'create') {
+					await onClose(data);
+				}
 			},
 			onSettled,
 		}),
@@ -55,6 +58,9 @@ export function CreateOrUpdateClientModal({
 		trpc.invoiceClient.update.mutationOptions({
 			onSuccess: async () => {
 				await setShowModal(false);
+				if (onClose && mode === 'update') {
+					await onClose();
+				}
 			},
 			onSettled,
 		}),
@@ -106,10 +112,10 @@ export function CreateOrUpdateClientModal({
 		focusGridList();
 		await queryClient.invalidateQueries(trpc.invoiceClient.byWorkspace.pathFilter());
 		await setShowModal(false);
-		if (onClose) {
+		if (onClose && mode === 'update') {
 			await onClose();
 		}
-	}, [focusGridList, queryClient, trpc.invoiceClient, setShowModal, onClose]);
+	}, [focusGridList, queryClient, trpc.invoiceClient, setShowModal, onClose, mode]);
 
 	const handleSubmit = useCallback(
 		async (data: z.infer<typeof upsertInvoiceClientSchema>) => {


### PR DESCRIPTION
On create invoice page, there is an option to create a new client. Right now, after that's done, the user then has to manually select the client from the dropdown. This PR adds functionality to automatically select the newly created client.

Closes #412

## Changes

- Modified `CreateOrUpdateClientModal` to pass created client data to onClose callback
- Updated `CreateInvoiceMultiStepForm` to handle the callback and auto-select the client
- Automatically moves to the details step after client creation

## Testing

1. Navigate to the create invoice page
2. Click "Add new client" from the client dropdown
3. Fill in client details and save
4. Verify the client is automatically selected and the form advances to the details step

Generated with [Claude Code](https://claude.ai/code)