### PR TITLE
fix: prevent invoice form reset before redirect completes

### DIFF
--- a/apps/app/src/app/[handle]/invoices/_components/create-invoice-multi-step-form.tsx
+++ b/apps/app/src/app/[handle]/invoices/_components/create-invoice-multi-step-form.tsx
@@ -259,9 +259,8 @@ export function CreateInvoiceMultiStepForm() {
 						trpc.invoice.getNextInvoiceNumber.queryKey(),
 					],
 				});
-				detailsForm.reset();
-				paymentForm.reset();
-				reviewForm.reset();
+				// Don't reset forms here - we're redirecting on success
+				// and on error the user should keep their data
 			},
 		}),
 	);


### PR DESCRIPTION
Fixes #414

The invoice creation form was resetting in the onSettled callback, which runs after both success and error. This caused the form to show $0 totals and empty line items before redirecting to the invoice page.

Since we redirect on success and want to preserve form data on error, there's no need to reset the forms at all in onSettled.

Generated with [Claude Code](https://claude.ai/code)