### PR TITLE
fix: replace hardcoded 'home' with dynamic bioKey in bio preview URLs

### DIFF
--- a/apps/app/src/app/[handle]/bios/_components/bio-contact-form-page.tsx
+++ b/apps/app/src/app/[handle]/bios/_components/bio-contact-form-page.tsx
@@ -141,7 +141,7 @@ export function BioContactFormPage({ blockId }: { blockId: string }) {
 			{/* Back link */}
 			<div className='mb-4'>
 				<Button
-					href={`/${handle}/bio/home/blocks`}
+					href={`/${handle}/bios/blocks?bioKey=${bioKey}`}
 					variant='button'
 					look='ghost'
 					size='sm'

--- a/packages/ui/src/bio/blocks/cart-block.tsx
+++ b/packages/ui/src/bio/blocks/cart-block.tsx
@@ -52,7 +52,7 @@ export function CartBlock({ block, blockIndex }: CartBlockProps) {
 	const { targetCartFunnel } = block;
 	const baseCheckoutUrl =
 		isPreview ?
-			`/${bio.handle}/bio/home/blocks?blockId=${block.id}`
+			`/${bio.handle}/bios/blocks?bioKey=${bio.key}&blockId=${block.id}`
 		:	getAbsoluteUrl('cart', `/${targetCartFunnel.handle}/${targetCartFunnel.key}`);
 
 	// Apply tracking parameters to checkout URL

--- a/packages/ui/src/bio/blocks/cta-button-server.tsx
+++ b/packages/ui/src/bio/blocks/cta-button-server.tsx
@@ -20,6 +20,7 @@ interface CtaButtonServerProps {
 	brandKit: BrandKit;
 	bio: {
 		handle: string;
+		key?: string;
 	};
 	isPreview?: boolean;
 	tracking?: BioTrackingData;
@@ -44,7 +45,9 @@ export function CtaButtonServer({
 	// Determine CTA href based on target type
 	const getCtaHref = () => {
 		if (isPreview) {
-			return `/${bio.handle}/bio/home/blocks?blockId=${block.id}`;
+			// Only generate preview URL if bio.key is available (client-side preview)
+			if (!bio.key) return '#';
+			return `/${bio.handle}/bios/blocks?bioKey=${bio.key}&blockId=${block.id}`;
 		}
 
 		let baseHref = '#';
@@ -54,7 +57,7 @@ export function CtaButtonServer({
 		} else if (block.targetBio) {
 			baseHref = getAbsoluteUrl(
 				'bio',
-				`/${block.targetBio.handle}/bio/${block.targetBio.key}`,
+				`/${block.targetBio.handle}/${block.targetBio.key}`,
 			);
 		} else if (block.targetFm) {
 			// FM routes not implemented yet

--- a/packages/ui/src/bio/blocks/cta-button.tsx
+++ b/packages/ui/src/bio/blocks/cta-button.tsx
@@ -43,7 +43,7 @@ export function CtaButton({ block, blockIndex, blockType, className }: CtaButton
 	// Determine CTA href based on target type
 	const getCtaHref = () => {
 		if (isPreview) {
-			return `/${bio.handle}/bio/home/blocks?blockId=${block.id}`;
+			return `/${bio.handle}/bios/blocks?bioKey=${bio.key}&blockId=${block.id}`;
 		}
 
 		let baseHref = '#';

--- a/packages/ui/src/bio/blocks/links-block.tsx
+++ b/packages/ui/src/bio/blocks/links-block.tsx
@@ -72,7 +72,7 @@ export function LinksBlock({ block, blockIndex }: LinksBlockProps) {
 				// Apply tracking parameters to the link href with journey context
 				const originalHref = link.url ?? '#';
 				const linkHref =
-					isPreview ? `/${bio.handle}/bio/home/links?blockId=${block.id}`
+					isPreview ? `/${bio.handle}/bios/links?bioKey=${bio.key}&blockId=${block.id}`
 					: tracking && originalHref !== '#' ?
 						getTrackingEnrichedHref({
 							href: originalHref,

--- a/packages/ui/src/bio/blocks/two-panel-block-shared.tsx
+++ b/packages/ui/src/bio/blocks/two-panel-block-shared.tsx
@@ -23,6 +23,7 @@ interface TwoPanelBlockSharedProps {
 	computedStyles: ComputedStyles;
 	bio: {
 		handle: string;
+		key?: string;
 	};
 	isPreview?: boolean;
 	tracking?: BioTrackingData;
@@ -129,7 +130,9 @@ export function TwoPanelBlockShared({
 	// Determine CTA href based on target type
 	const getCtaHref = () => {
 		if (isPreview) {
-			return `/${bio.handle}/bio/home/blocks?blockId=${block.id}`;
+			// Only generate preview URL if bio.key is available (client-side preview)
+			if (!bio.key) return '#';
+			return `/${bio.handle}/bios/blocks?bioKey=${bio.key}&blockId=${block.id}`;
 		}
 
 		let baseHref = '#';


### PR DESCRIPTION
Fixes #416

## Summary

This PR replaces all hardcoded `/bio/home/` paths with the correct format using dynamic `bioKey`:
- Old: `/{handle}/bio/home/links?blockId={blockId}`
- New: `/{handle}/bios/links?bioKey={bioKey}&blockId={blockId}`

## Changes

1. Updated preview URLs in 6 files to use the correct format
2. Made `bio.key` optional in server components that only receive `bio.handle`
3. Fixed targetBio URL format in `cta-button-server.tsx` (removed extra '/bio')
4. All changes pass TypeScript, linting, and formatting checks

## Testing

- ✅ TypeScript compilation passes
- ✅ ESLint checks pass
- ✅ Prettier formatting applied

## Files Changed

- `packages/ui/src/bio/blocks/links-block.tsx`
- `packages/ui/src/bio/blocks/cart-block.tsx`
- `packages/ui/src/bio/blocks/cta-button.tsx`
- `packages/ui/src/bio/blocks/cta-button-server.tsx`
- `packages/ui/src/bio/blocks/two-panel-block-shared.tsx`
- `apps/app/src/app/[handle]/bios/_components/bio-contact-form-page.tsx`

🤖 Generated with [Claude Code](https://claude.ai/code)