### PR TITLE
feat: add apparel sizes to cart receipt emails

### DIFF
--- a/packages/email/src/templates/cart/receipt.tsx
+++ b/packages/email/src/templates/cart/receipt.tsx
@@ -55,6 +55,7 @@ export interface ReceiptEmailProps {
 		price: string;
 		payWhatYouWantPrice?: string;
 		shipping?: string;
+		size?: string;
 	}[];
 	shippingTotal?: string;
 	vatTotal: string | null;
@@ -264,6 +265,19 @@ export function ReceiptEmailTemplate({
 												</Text>
 											)}
 
+											{product.size && (
+												<Text
+													style={{
+														...resetText,
+														...mutedText,
+														marginTop: '4px',
+														fontSize: '12px',
+													}}
+												>
+													Size: {product.size}
+												</Text>
+											)}
+
 											{product.shipping && (
 												<Text
 													style={{
@@ -396,6 +410,11 @@ ReceiptEmailTemplate.PreviewProps = {
 		{
 			name: 'Rusty Grand Am :: Pre-Order CD',
 			price: '$10.00',
+		},
+		{
+			name: 'Band T-Shirt',
+			price: '$25.00',
+			size: 'L',
 		},
 	],
 	vatTotal: '£20.00',

--- a/packages/lib/src/functions/cart.fns.ts
+++ b/packages/lib/src/functions/cart.fns.ts
@@ -9,7 +9,7 @@ import type {
 	stripeConnectChargeMetadataSchema,
 } from '@barely/validators/schemas';
 import type { z } from 'zod/v4';
-import { MEDIAMAIL_TYPES, MERCH_DIMENSIONS } from '@barely/const';
+import { APPAREL_TYPES, MEDIAMAIL_TYPES, MERCH_DIMENSIONS } from '@barely/const';
 import { dbHttp } from '@barely/db/client';
 import {
 	CartFunnels,
@@ -478,6 +478,13 @@ export async function sendCartReceiptEmail(cart: ReceiptCart) {
 						cart.currency,
 					)
 				:	undefined,
+			size:
+				(
+					cart.mainProductApparelSize &&
+					APPAREL_TYPES.some(type => type === cart.mainProduct.merchType)
+				) ?
+					cart.mainProductApparelSize
+				:	undefined,
 		},
 
 		// bump product
@@ -490,6 +497,13 @@ export async function sendCartReceiptEmail(cart: ReceiptCart) {
 						cart.bumpShippingAndHandlingAmount ?? 0,
 						cart.currency,
 					),
+					size:
+						(
+							cart.bumpProductApparelSize &&
+							APPAREL_TYPES.some(type => type === cart.bumpProduct.merchType)
+						) ?
+							cart.bumpProductApparelSize
+						:	undefined,
 				},
 			]
 		:	[]),
@@ -504,6 +518,13 @@ export async function sendCartReceiptEmail(cart: ReceiptCart) {
 						cart.upsellShippingAndHandlingAmount ?? 0,
 						cart.currency,
 					),
+					size:
+						(
+							cart.upsellProductApparelSize &&
+							APPAREL_TYPES.some(type => type === cart.upsellProduct.merchType)
+						) ?
+							cart.upsellProductApparelSize
+						:	undefined,
 				},
 			]
 		:	[]),


### PR DESCRIPTION
Fixes #420

This PR adds apparel sizes to cart receipt emails so customers have a record of their chosen sizes.

## Changes
- Add size field to ReceiptEmailProps products array
- Display size in receipt email template for apparel items
- Include apparel sizes from cart data for main, bump, and upsell products
- Only show sizes for tshirt and sweatshirt product types

## Testing
- [ ] Test receipt email generation with apparel items
- [ ] Test receipt email generation with non-apparel items
- [ ] Test receipt email generation with mixed items

🤖 Generated with [Claude Code](https://claude.ai/code)